### PR TITLE
fix: normalize column names checking for matches

### DIFF
--- a/sqlframe/base/dataframe.py
+++ b/sqlframe/base/dataframe.py
@@ -1093,15 +1093,16 @@ class _BaseDataFrame(t.Generic[SESSION, WRITER, NA, STAT, GROUP_DATA]):
     @operation(Operation.SELECT)
     def withColumn(self, colName: str, col: Column) -> Self:
         col = self._ensure_and_normalize_col(col)
+        col_name = self._ensure_and_normalize_col(colName).alias_or_name
         existing_col_names = self.expression.named_selects
         existing_col_index = (
-            existing_col_names.index(colName) if colName in existing_col_names else None
+            existing_col_names.index(col_name) if col_name in existing_col_names else None
         )
         if existing_col_index:
             expression = self.expression.copy()
-            expression.expressions[existing_col_index] = col.alias(colName).expression
+            expression.expressions[existing_col_index] = col.alias(col_name).expression
             return self.copy(expression=expression)
-        return self.copy().select(col.alias(colName), append=True)
+        return self.copy().select(col.alias(col_name), append=True)
 
     @operation(Operation.SELECT)
     def withColumnRenamed(self, existing: str, new: str) -> Self:

--- a/tests/unit/standalone/test_dataframe.py
+++ b/tests/unit/standalone/test_dataframe.py
@@ -48,7 +48,7 @@ def test_persist_storagelevel(standalone_employee: StandaloneDataFrame, compare_
 
 
 def test_with_column_duplicate_alias(standalone_employee: StandaloneDataFrame):
-    df = standalone_employee.withColumn("fname", F.col("age").cast("string"))
+    df = standalone_employee.withColumn("fName", F.col("age").cast("string"))
     assert df.columns == ["employee_id", "fname", "lname", "age", "store_id"]
     # Make sure that the new columns is added with an alias to `fname`
     assert (


### PR DESCRIPTION
Prior to this change if someone provided a column that had mixed case but their engine was case sensitive we wouldn't see this as a duplicate column name to replace the existing one and therefore create a duplicate column. This normalizes the value so the check should be correct now. 