### PR TITLE
fix: Snowflake to properly convert variant types

### DIFF
--- a/sqlframe/base/session.py
+++ b/sqlframe/base/session.py
@@ -450,14 +450,6 @@ class _BaseSession(t.Generic[CATALOG, READER, WRITER, DF, CONN]):
     def _fetch_rows(
         self, sql: t.Union[str, exp.Expression], *, quote_identifiers: bool = True
     ) -> t.List[Row]:
-        from sqlframe.base.types import Row
-
-        def _dict_to_row(row: t.Dict[str, t.Any]) -> Row:
-            for key, value in row.items():
-                if isinstance(value, dict):
-                    row[key] = _dict_to_row(value)
-            return Row(**row)
-
         self._execute(sql, quote_identifiers=quote_identifiers)
         result = self._cur.fetchall()
         if not self._cur.description:

--- a/sqlframe/snowflake/session.py
+++ b/sqlframe/snowflake/session.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
+import json
 import typing as t
 import warnings
+
+try:
+    from snowflake.connector.converter import SnowflakeConverter
+except ImportError:
+    SnowflakeConverter = object  # type: ignore
 
 from sqlframe.base.session import _BaseSession
 from sqlframe.snowflake.catalog import SnowflakeCatalog
@@ -15,6 +21,18 @@ if t.TYPE_CHECKING:
     from snowflake.connector import SnowflakeConnection
 else:
     SnowflakeConnection = t.Any
+
+
+class JsonLoadsSnowflakeConverter(SnowflakeConverter):
+    def _json_loads(self, ctx: dict[str, t.Any]) -> t.Callable:
+        def conv(value: str) -> t.List:
+            return json.loads(value)
+
+        return conv
+
+    _OBJECT_to_python = _json_loads  # type: ignore
+    _VARIANT_to_python = _json_loads  # type: ignore
+    _ARRAY_to_python = _json_loads  # type: ignore
 
 
 class SnowflakeSession(
@@ -35,8 +53,21 @@ class SnowflakeSession(
         warnings.warn(
             "SnowflakeSession is still in active development. Functions may not work as expected."
         )
+        import snowflake
+
+        snowflake.connector.cursor.CAN_USE_ARROW_RESULT_FORMAT = False
+
         if not hasattr(self, "_conn"):
             super().__init__(conn)
+            if self._conn.converter and not isinstance(
+                self._conn.converter, JsonLoadsSnowflakeConverter
+            ):
+                self._conn.converter = JsonLoadsSnowflakeConverter(
+                    use_numpy=self._conn._numpy,
+                    support_negative_year=self._conn._support_negative_year,
+                )
+            else:
+                self._conn._converter_class = JsonLoadsSnowflakeConverter  # type: ignore
 
     class Builder(_BaseSession.Builder):
         DEFAULT_INPUT_DIALECT = "snowflake"

--- a/tests/integration/engines/test_int_functions.py
+++ b/tests/integration/engines/test_int_functions.py
@@ -18,6 +18,7 @@ from sqlframe.base.util import (
 from sqlframe.bigquery import BigQuerySession
 from sqlframe.duckdb import DuckDBSession
 from sqlframe.postgres import PostgresDataFrame, PostgresSession
+from sqlframe.snowflake import SnowflakeSession
 from sqlframe.spark.session import SparkSession
 
 if t.TYPE_CHECKING:
@@ -138,6 +139,9 @@ def test_lit(get_session_and_func, arg, expected):
     if isinstance(session, SparkSession):
         if isinstance(arg, datetime.datetime) and arg.tzinfo is not None:
             pytest.skip("Spark doesn't preserve timezone information in datetime literals")
+    if isinstance(session, SnowflakeSession):
+        if isinstance(arg, Row):
+            pytest.skip("Snowflake doesn't support literal row types")
     assert session.range(1).select(lit(arg).alias("test")).collect() == [Row(test=expected)]
 
 


### PR DESCRIPTION
Snowflake by default leaves variant types like arrays and dicts as strings instead of their python types. In order for this to work we had to disable arrow conversion on Snowflake. See this PR for more details and eventual support for arrow so we don't have to do this anymore: https://github.com/snowflakedb/snowflake-connector-python/issues/544

Related to: https://github.com/eakmanrq/sqlframe/issues/31

Video of me working on this: https://www.loom.com/share/945f5ad460f3475bb3a8ccce37d52ec3?sid=c16413b1-2ced-47b3-9c6b-1ec1d5a2f647