### PR TITLE
feat: add openai enrichment support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "dev": [
             "duckdb>=0.9,<0.11",
             "mypy>=1.10.0,<1.11",
+            "openai>=1.30,<1.31",
             "pandas>=2,<3",
             "pandas-stubs>=2,<3",
             "psycopg>=3.1,<4",
@@ -54,6 +55,9 @@ setup(
         "duckdb": [
             "duckdb>=0.9,<0.11",
             "pandas>=2,<3",
+        ],
+        "openai": [
+            "openai>=1.30,<1.31",
         ],
         "pandas": [
             "pandas>=2,<3",

--- a/sqlframe/base/util.py
+++ b/sqlframe/base/util.py
@@ -256,6 +256,15 @@ def verify_pandas_installed():
         )
 
 
+def verify_openai_installed():
+    try:
+        import openai  # noqa
+    except ImportError:
+        raise ImportError(
+            """OpenAI is required for this functionality. `pip install "sqlframe[openai]"` (also include your engine if needed) to install openai."""
+        )
+
+
 def quote_preserving_alias_or_name(col: t.Union[exp.Column, exp.Alias]) -> str:
     from sqlframe.base.session import _BaseSession
 


### PR DESCRIPTION
Adds the ability to use ChatGPT to enrich generated SQL in order to make it more like human SQL. The SQL used by SQLFrame when executing queries does not use optimization or ChatGPT so this just affects when a user calls `df.sql()` directly in order to see the generated SQL. 

Video: https://www.loom.com/share/3fab8493818b46f7bff03faf101d2bb6?sid=ba027a0c-4ab7-4531-a4f8-f1a95b70d7e6