### PR TITLE
fix: properly include typing files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author="Ryan Eakman",
     author_email="eakmanrq@gmail.com",
     license="MIT",
-    packages=find_packages(include=["sqlframe", "sqlframe.*"]),
+    packages=find_packages(include=["sqlframe", "sqlframe.*", "py.typed", "*.pyi", "**/*.pyi"]),
     package_data={"sqlframe": ["py.typed"]},
     use_scm_version={
         "write_to": "sqlframe/_version.py",


### PR DESCRIPTION
Prior to this the wheel for sqlframe wasn't including the typed files which are used to properly show what functions are available for each dataframe. 