### PR TITLE
chore: add nullif to all engine types

### DIFF
--- a/sqlframe/bigquery/functions.pyi
+++ b/sqlframe/bigquery/functions.pyi
@@ -189,6 +189,7 @@ from sqlframe.base.functions import min as min
 from sqlframe.base.functions import min_by as min_by
 from sqlframe.base.functions import nth_value as nth_value
 from sqlframe.base.functions import ntile as ntile
+from sqlframe.base.functions import nullif as nullif
 from sqlframe.base.functions import octet_length as octet_length
 from sqlframe.base.functions import percent_rank as percent_rank
 from sqlframe.base.functions import posexplode as posexplode

--- a/sqlframe/duckdb/functions.pyi
+++ b/sqlframe/duckdb/functions.pyi
@@ -126,6 +126,7 @@ from sqlframe.base.functions import (
     months_between as months_between,
     nth_value as nth_value,
     ntile as ntile,
+    nullif as nullif,
     percent_rank as percent_rank,
     percentile as percentile,
     pow as pow,

--- a/sqlframe/postgres/functions.pyi
+++ b/sqlframe/postgres/functions.pyi
@@ -119,6 +119,7 @@ from sqlframe.base.functions import (
     min as min,
     nth_value as nth_value,
     ntile as ntile,
+    nullif as nullif,
     octet_length as octet_length,
     overlay as overlay,
     percent_rank as percent_rank,


### PR DESCRIPTION
`nullif` was already added but it just wasn't added to each engine's types.

PR where it was added: https://github.com/eakmanrq/sqlframe/pull/39