### PR TITLE
feat: add withColumns support

### DIFF
--- a/sqlframe/base/dataframe.py
+++ b/sqlframe/base/dataframe.py
@@ -60,7 +60,6 @@ else:
     SESSION = t.TypeVar("SESSION")
     GROUP_DATA = t.TypeVar("GROUP_DATA")
 
-
 logger = logging.getLogger(__name__)
 
 JOIN_HINTS = {
@@ -1178,17 +1177,7 @@ class _BaseDataFrame(t.Generic[SESSION, WRITER, NA, STAT, GROUP_DATA]):
 
     @operation(Operation.SELECT)
     def withColumn(self, colName: str, col: Column) -> Self:
-        col = self._ensure_and_normalize_col(col)
-        col_name = self._ensure_and_normalize_col(colName).alias_or_name
-        existing_col_names = self.expression.named_selects
-        existing_col_index = (
-            existing_col_names.index(col_name) if col_name in existing_col_names else None
-        )
-        if existing_col_index:
-            expression = self.expression.copy()
-            expression.expressions[existing_col_index] = col.alias(col_name).expression
-            return self.copy(expression=expression)
-        return self.select.__wrapped__(self, col.alias(col_name), append=True)  # type: ignore
+        return self.withColumns.__wrapped__(self, {colName: col})  # type: ignore
 
     @operation(Operation.SELECT)
     def withColumnRenamed(self, existing: str, new: str) -> Self:
@@ -1208,6 +1197,66 @@ class _BaseDataFrame(t.Generic[SESSION, WRITER, NA, STAT, GROUP_DATA]):
             else:
                 existing_column.set("alias", exp.to_identifier(new))
         return self.copy(expression=expression)
+
+    @operation(Operation.SELECT)
+    def withColumns(self, *colsMap: t.Dict[str, Column]) -> Self:
+        """
+        Returns a new :class:`DataFrame` by adding multiple columns or replacing the
+        existing columns that have the same names.
+
+        The colsMap is a map of column name and column, the column must only refer to attributes
+        supplied by this Dataset. It is an error to add columns that refer to some other Dataset.
+
+        .. versionadded:: 3.3.0
+           Added support for multiple columns adding
+
+        .. versionchanged:: 3.4.0
+            Supports Spark Connect.
+
+        Parameters
+        ----------
+        colsMap : dict
+            a dict of column name and :class:`Column`. Currently, only a single map is supported.
+
+        Returns
+        -------
+        :class:`DataFrame`
+            DataFrame with new or replaced columns.
+
+        Examples
+        --------
+        >>> df = spark.createDataFrame([(2, "Alice"), (5, "Bob")], schema=["age", "name"])
+        >>> df.withColumns({'age2': df.age + 2, 'age3': df.age + 3}).show()
+        +---+-----+----+----+
+        |age| name|age2|age3|
+        +---+-----+----+----+
+        |  2|Alice|   4|   5|
+        |  5|  Bob|   7|   8|
+        +---+-----+----+----+
+        """
+        if len(colsMap) != 1:
+            raise ValueError("Only a single map is supported")
+        col_map = {
+            self._ensure_and_normalize_col(k).alias_or_name: self._ensure_and_normalize_col(v)
+            for k, v in colsMap[0].items()
+        }
+        existing_col_names = [
+            x.alias_or_name for x in self._get_outer_select_columns(self.expression)
+        ]
+        updated_expression = self.expression.copy()
+        select_columns = []
+        for column_name, col_value in col_map.items():
+            existing_col_index = (
+                existing_col_names.index(column_name) if column_name in existing_col_names else None
+            )
+            if existing_col_index:
+                updated_expression.expressions[existing_col_index] = col_value.alias(
+                    column_name
+                ).expression
+            else:
+                select_columns.append(col_value.alias(column_name))
+        df = self.copy(expression=updated_expression)
+        return df.select.__wrapped__(df, *select_columns, append=True)  # type: ignore
 
     @operation(Operation.SELECT)
     def drop(self, *cols: t.Union[str, Column]) -> Self:

--- a/tests/unit/standalone/test_dataframe.py
+++ b/tests/unit/standalone/test_dataframe.py
@@ -57,6 +57,23 @@ def test_with_column_duplicate_alias(standalone_employee: StandaloneDataFrame):
     )
 
 
+def test_with_columns(standalone_employee: StandaloneDataFrame):
+    df = standalone_employee.withColumns({"new_col1": F.col("age"), "new_col2": F.col("store_id")})
+    assert df.columns == [
+        "employee_id",
+        "fname",
+        "lname",
+        "age",
+        "store_id",
+        "new_col1",
+        "new_col2",
+    ]
+    assert (
+        df.sql(pretty=False)
+        == "SELECT `a1`.`employee_id` AS `employee_id`, CAST(`a1`.`fname` AS STRING) AS `fname`, CAST(`a1`.`lname` AS STRING) AS `lname`, `a1`.`age` AS `age`, `a1`.`store_id` AS `store_id`, `a1`.`age` AS `new_col1`, `a1`.`store_id` AS `new_col2` FROM VALUES (1, 'Jack', 'Shephard', 37, 1), (2, 'John', 'Locke', 65, 1), (3, 'Kate', 'Austen', 37, 2), (4, 'Claire', 'Littleton', 27, 2), (5, 'Hugo', 'Reyes', 29, 100) AS `a1`(`employee_id`, `fname`, `lname`, `age`, `store_id`)"
+    )
+
+
 # https://github.com/eakmanrq/sqlframe/issues/19
 def test_with_column_dual_expression(standalone_employee: StandaloneDataFrame):
     df1 = standalone_employee.withColumn("new_col1", standalone_employee.age)


### PR DESCRIPTION
Add support for `withColumns`: https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.withColumns.html

Related to: https://github.com/eakmanrq/sqlframe/issues/45