### PR TITLE
feat: add transform support

### DIFF
--- a/sqlframe/base/dataframe.py
+++ b/sqlframe/base/dataframe.py
@@ -641,6 +641,9 @@ class _BaseDataFrame(t.Generic[SESSION, WRITER, NA, STAT, GROUP_DATA]):
     def select(self, *cols, **kwargs) -> Self:
         from sqlframe.base.column import Column
 
+        if not cols:
+            return self
+
         if isinstance(cols[0], list):
             cols = cols[0]  # type: ignore
         columns = self._ensure_and_normalize_cols(cols)

--- a/tests/integration/test_int_dataframe.py
+++ b/tests/integration/test_int_dataframe.py
@@ -1978,3 +1978,24 @@ def test_persist_select(
         store.store_id, dfs_employee.num_employees
     )
     compare_frames(df_joined, dfs_joined)
+
+
+def test_transform(
+    pyspark_employee: PySparkDataFrame,
+    get_df: t.Callable[[str], _BaseDataFrame],
+    compare_frames: t.Callable,
+):
+    def cast_all_to_int_pyspark(input_df):
+        return input_df.select([F.col(col_name).cast("string") for col_name in input_df.columns])
+
+    def cast_all_to_int_sqlframe(input_df):
+        return input_df.select([SF.col(col_name).cast("string") for col_name in input_df.columns])
+
+    def sort_columns_asc(input_df):
+        return input_df.select(*sorted(input_df.columns))
+
+    employee = get_df("employee")
+
+    df = pyspark_employee.transform(cast_all_to_int_pyspark).transform(sort_columns_asc)
+    dfs = employee.transform(cast_all_to_int_sqlframe).transform(sort_columns_asc)
+    compare_frames(df, dfs)

--- a/tests/unit/standalone/test_dataframe.py
+++ b/tests/unit/standalone/test_dataframe.py
@@ -57,6 +57,20 @@ def test_with_column_duplicate_alias(standalone_employee: StandaloneDataFrame):
     )
 
 
+def test_transform(standalone_employee: StandaloneDataFrame):
+    def cast_all_to_int(input_df):
+        return input_df.select([F.col(col_name).cast("int") for col_name in input_df.columns])
+
+    def sort_columns_asc(input_df):
+        return input_df.select(*sorted(input_df.columns))
+
+    df = standalone_employee.transform(cast_all_to_int).transform(sort_columns_asc)
+    assert df.columns == ["age", "employee_id", "fname", "lname", "store_id"]
+    assert df.sql(pretty=False, optimize=False).endswith(  # type: ignore
+        "SELECT CAST(employee_id AS INT) AS employee_id, CAST(fname AS INT) AS fname, CAST(lname AS INT) AS lname, CAST(age AS INT) AS age, CAST(store_id AS INT) AS store_id FROM t51718876) SELECT age, employee_id, fname, lname, store_id FROM t16881256"
+    )
+
+
 # https://github.com/eakmanrq/sqlframe/issues/19
 def test_with_column_dual_expression(standalone_employee: StandaloneDataFrame):
     df1 = standalone_employee.withColumn("new_col1", standalone_employee.age)

--- a/tests/unit/standalone/test_dataframe.py
+++ b/tests/unit/standalone/test_dataframe.py
@@ -85,6 +85,7 @@ def test_transform(standalone_employee: StandaloneDataFrame):
     assert df.columns == ["age", "employee_id", "fname", "lname", "store_id"]
     assert df.sql(pretty=False, optimize=False).endswith(  # type: ignore
         "SELECT CAST(employee_id AS INT) AS employee_id, CAST(fname AS INT) AS fname, CAST(lname AS INT) AS lname, CAST(age AS INT) AS age, CAST(store_id AS INT) AS store_id FROM t51718876) SELECT age, employee_id, fname, lname, store_id FROM t16881256"
+    )
 
 
 # https://github.com/eakmanrq/sqlframe/issues/19


### PR DESCRIPTION
Adds support for DataFrame `transform` method: https://spark.apache.org/docs/3.1.3/api/python/reference/api/pyspark.sql.DataFrame.transform.html

Related to: https://github.com/eakmanrq/sqlframe/issues/45