### PR TITLE
fix: properly identify ambiguous column with an alias

### DIFF
--- a/sqlframe/base/column.py
+++ b/sqlframe/base/column.py
@@ -247,6 +247,10 @@ class Column:
     def alias_or_name(self) -> str:
         return quote_preserving_alias_or_name(self.expression)  # type: ignore
 
+    @property
+    def column_alias_or_name(self) -> str:
+        return quote_preserving_alias_or_name(self.column_expression)  # type: ignore
+
     @classmethod
     def ensure_literal(cls, value) -> Column:
         from sqlframe.base.functions import lit

--- a/sqlframe/base/dataframe.py
+++ b/sqlframe/base/dataframe.py
@@ -668,7 +668,7 @@ class _BaseDataFrame(t.Generic[SESSION, WRITER, NA, STAT, GROUP_DATA]):
                         cte
                         for cte in self.expression.ctes
                         if cte.alias_or_name in cte_names_in_join
-                        and ambiguous_col.alias_or_name in cte.this.named_selects
+                        and ambiguous_col.column_alias_or_name in cte.this.named_selects
                     ]
                     # Check if there is a CTE with this column that we haven't used before. If so, use it. Otherwise,
                     # use the same CTE we used before
@@ -677,7 +677,9 @@ class _BaseDataFrame(t.Generic[SESSION, WRITER, NA, STAT, GROUP_DATA]):
                         resolved_column_position[ambiguous_col] += 1
                     else:
                         cte = ctes_with_column[resolved_column_position[ambiguous_col]]
-                    ambiguous_col.expression.set("table", exp.to_identifier(cte.alias_or_name))
+                    ambiguous_col.column_expression.set(
+                        "table", exp.to_identifier(cte.alias_or_name)
+                    )
         # If an expression is `CAST(x AS DATETYPE)` then we want to alias so that `x` is the result column name
         columns = [
             col.alias(col.expression.alias_or_name)

--- a/tests/integration/test_int_dataframe.py
+++ b/tests/integration/test_int_dataframe.py
@@ -375,7 +375,7 @@ def test_join_inner(
         pyspark_employee["fname"],
         F.col("lname"),
         F.col("age"),
-        F.col("store_id"),
+        F.col("store_id").alias("renamed_store_id"),
         pyspark_store.store_name,
         pyspark_store["num_sales"],
     )
@@ -384,7 +384,7 @@ def test_join_inner(
         employee["fname"],
         SF.col("lname"),
         SF.col("age"),
-        SF.col("store_id"),
+        SF.col("store_id").alias("renamed_store_id"),
         store.store_name,
         store["num_sales"],
     )


### PR DESCRIPTION
I checked the `column_expressions` for ambiguity but then later I just referred to the column itself for checking the name and updating the table reference. Now it consistently checks for the column_expression and the test was updated to properly verify this.

Fixes: https://github.com/eakmanrq/sqlframe/issues/50

