### PR TITLE
fix: select after join detect all possible columns

### DIFF
--- a/tests/integration/test_int_dataframe.py
+++ b/tests/integration/test_int_dataframe.py
@@ -375,7 +375,7 @@ def test_join_inner(
         pyspark_employee["fname"],
         F.col("lname"),
         F.col("age"),
-        F.col("store_id").alias("renamed_store_id"),
+        F.coalesce("store_id", "age").alias("store_id_size"),
         pyspark_store.store_name,
         pyspark_store["num_sales"],
     )
@@ -384,7 +384,7 @@ def test_join_inner(
         employee["fname"],
         SF.col("lname"),
         SF.col("age"),
-        SF.col("store_id").alias("renamed_store_id"),
+        SF.coalesce("store_id", "age").alias("store_id_size"),
         store.store_name,
         store["num_sales"],
     )


### PR DESCRIPTION
Prior to this the code assumed that the columns in a select with ambiguous references were just column expressions but not it will search out all columns that might be ambiguous and therefore they can be more complex. 

Fixes: https://github.com/eakmanrq/sqlframe/issues/50