### PR TITLE
fix: ignore conf if passed in config

### DIFF
--- a/sqlframe/base/session.py
+++ b/sqlframe/base/session.py
@@ -569,6 +569,7 @@ class _BaseSession(t.Generic[CATALOG, READER, WRITER, DF, CONN]):
             self,
             key: t.Optional[str] = None,
             value: t.Optional[t.Any] = None,
+            conf: t.Optional[t.Any] = None,
             *,
             map: t.Optional[t.Dict[str, t.Any]] = None,
         ) -> Self:


### PR DESCRIPTION
Potentially the more robust solution would be to parse the SparkConf object and check if it contains any SQLFrame related config but the documentation doesn't say this is supported and I wouldn't be surprised if not one does that so just ignoring for now. 

For Spark engine the conf object is passed through (method is overriden). 