### PR TITLE
feat: add printSchema to BQ and Snowflake

### DIFF
--- a/docs/bigquery.md
+++ b/docs/bigquery.md
@@ -217,6 +217,7 @@ See something that you would like to see supported? [Open an issue](https://gith
 * [na](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.na.html)
 * [orderBy](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.orderBy.html)
 * [persist](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.persist.html)
+* [printSchema](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.printSchema.html)
 * [replace](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.replace.html)
 * [select](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.select.html)
 * [show](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.show.html)

--- a/docs/snowflake.md
+++ b/docs/snowflake.md
@@ -212,6 +212,7 @@ See something that you would like to see supported? [Open an issue](https://gith
 * [na](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.na.html)
 * [orderBy](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.orderBy.html)
 * [persist](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.persist.html)
+* [printSchema](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.printSchema.html)
 * [replace](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.replace.html)
 * [select](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.select.html)
 * [show](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.show.html)

--- a/sqlframe/base/mixins/dataframe_mixins.py
+++ b/sqlframe/base/mixins/dataframe_mixins.py
@@ -1,3 +1,5 @@
+import logging
+import sys
 import typing as t
 
 from sqlglot import exp
@@ -12,11 +14,30 @@ from sqlframe.base.dataframe import (
     _BaseDataFrame,
 )
 
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
-class PrintSchemaFromTempObjectsMixin(
+
+logger = logging.getLogger(__name__)
+
+
+class NoCachePersistSupportMixin(_BaseDataFrame, t.Generic[SESSION, WRITER, NA, STAT, GROUP_DATA]):
+    def cache(self) -> Self:
+        logger.warning("This engine does not support caching. Ignoring cache() call.")
+        return self
+
+    def persist(self) -> Self:
+        logger.warning("This engine does not support persist. Ignoring persist() call.")
+        return self
+
+
+class TypedColumnsFromTempViewMixin(
     _BaseDataFrame, t.Generic[SESSION, WRITER, NA, STAT, GROUP_DATA]
 ):
-    def _get_columns_from_temp_object(self) -> t.List[Column]:
+    @property
+    def _typed_columns(self) -> t.List[Column]:
         table = exp.to_table(self.session._random_id)
         self.session._execute(
             exp.Create(
@@ -27,37 +48,7 @@ class PrintSchemaFromTempObjectsMixin(
                 expression=self.expression,
             )
         )
+
         return self.session.catalog.listColumns(
             table.sql(dialect=self.session.input_dialect), include_temp=True
         )
-
-    def printSchema(self, level: t.Optional[int] = None) -> None:
-        def print_schema(
-            column_name: str, column_type: exp.DataType, nullable: bool, current_level: int
-        ):
-            if level and current_level >= level:
-                return
-            if current_level > 0:
-                print(" |   " * current_level, end="")
-            print(
-                f" |-- {column_name}: {column_type.sql(self.session.output_dialect).lower()} (nullable = {str(nullable).lower()})"
-            )
-            if column_type.this == exp.DataType.Type.STRUCT:
-                for column_def in column_type.expressions:
-                    print_schema(column_def.name, column_def.args["kind"], True, current_level + 1)
-            if column_type.this == exp.DataType.Type.ARRAY:
-                for data_type in column_type.expressions:
-                    print_schema("element", data_type, True, current_level + 1)
-            if column_type.this == exp.DataType.Type.MAP:
-                print_schema("key", column_type.expressions[0], True, current_level + 1)
-                print_schema("value", column_type.expressions[1], True, current_level + 1)
-
-        columns = self._get_columns_from_temp_object()
-        print("root")
-        for column in columns:
-            print_schema(
-                column.name,
-                exp.DataType.build(column.dataType, dialect=self.session.output_dialect),
-                column.nullable,
-                0,
-            )

--- a/sqlframe/duckdb/dataframe.py
+++ b/sqlframe/duckdb/dataframe.py
@@ -4,18 +4,19 @@ import logging
 import sys
 import typing as t
 
+from sqlglot import exp
+
+from sqlframe.base.catalog import Column
 from sqlframe.base.dataframe import (
     _BaseDataFrame,
     _BaseDataFrameNaFunctions,
     _BaseDataFrameStatFunctions,
 )
-from sqlframe.base.mixins.dataframe_mixins import PrintSchemaFromTempObjectsMixin
+from sqlframe.base.mixins.dataframe_mixins import (
+    NoCachePersistSupportMixin,
+    TypedColumnsFromTempViewMixin,
+)
 from sqlframe.duckdb.group import DuckDBGroupedData
-
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
 
 if t.TYPE_CHECKING:
     from sqlframe.duckdb.session import DuckDBSession  # noqa
@@ -35,7 +36,8 @@ class DuckDBDataFrameStatFunctions(_BaseDataFrameStatFunctions["DuckDBDataFrame"
 
 
 class DuckDBDataFrame(
-    PrintSchemaFromTempObjectsMixin,
+    NoCachePersistSupportMixin,
+    TypedColumnsFromTempViewMixin,
     _BaseDataFrame[
         "DuckDBSession",
         "DuckDBDataFrameWriter",
@@ -47,11 +49,3 @@ class DuckDBDataFrame(
     _na = DuckDBDataFrameNaFunctions
     _stat = DuckDBDataFrameStatFunctions
     _group_data = DuckDBGroupedData
-
-    def cache(self) -> Self:
-        logger.warning("DuckDB does not support caching. Ignoring cache() call.")
-        return self
-
-    def persist(self) -> Self:
-        logger.warning("DuckDB does not support persist. Ignoring persist() call.")
-        return self

--- a/sqlframe/postgres/dataframe.py
+++ b/sqlframe/postgres/dataframe.py
@@ -9,7 +9,10 @@ from sqlframe.base.dataframe import (
     _BaseDataFrameNaFunctions,
     _BaseDataFrameStatFunctions,
 )
-from sqlframe.base.mixins.dataframe_mixins import PrintSchemaFromTempObjectsMixin
+from sqlframe.base.mixins.dataframe_mixins import (
+    NoCachePersistSupportMixin,
+    TypedColumnsFromTempViewMixin,
+)
 from sqlframe.postgres.group import PostgresGroupedData
 
 if sys.version_info >= (3, 11):
@@ -34,7 +37,8 @@ class PostgresDataFrameStatFunctions(_BaseDataFrameStatFunctions["PostgresDataFr
 
 
 class PostgresDataFrame(
-    PrintSchemaFromTempObjectsMixin,
+    NoCachePersistSupportMixin,
+    TypedColumnsFromTempViewMixin,
     _BaseDataFrame[
         "PostgresSession",
         "PostgresDataFrameWriter",
@@ -46,11 +50,3 @@ class PostgresDataFrame(
     _na = PostgresDataFrameNaFunctions
     _stat = PostgresDataFrameStatFunctions
     _group_data = PostgresGroupedData
-
-    def cache(self) -> Self:
-        logger.warning("Postgres does not support caching. Ignoring cache() call.")
-        return self
-
-    def persist(self) -> Self:
-        logger.warning("Postgres does not support persist. Ignoring persist() call.")
-        return self

--- a/sqlframe/redshift/dataframe.py
+++ b/sqlframe/redshift/dataframe.py
@@ -9,12 +9,8 @@ from sqlframe.base.dataframe import (
     _BaseDataFrameNaFunctions,
     _BaseDataFrameStatFunctions,
 )
+from sqlframe.base.mixins.dataframe_mixins import NoCachePersistSupportMixin
 from sqlframe.redshift.group import RedshiftGroupedData
-
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
 
 if t.TYPE_CHECKING:
     from sqlframe.redshift.readwriter import RedshiftDataFrameWriter
@@ -33,22 +29,15 @@ class RedshiftDataFrameStatFunctions(_BaseDataFrameStatFunctions["RedshiftDataFr
 
 
 class RedshiftDataFrame(
+    NoCachePersistSupportMixin,
     _BaseDataFrame[
         "RedshiftSession",
         "RedshiftDataFrameWriter",
         "RedshiftDataFrameNaFunctions",
         "RedshiftDataFrameStatFunctions",
         "RedshiftGroupedData",
-    ]
+    ],
 ):
     _na = RedshiftDataFrameNaFunctions
     _stat = RedshiftDataFrameStatFunctions
     _group_data = RedshiftGroupedData
-
-    def cache(self) -> Self:
-        logger.warning("Redshift does not support caching. Ignoring cache() call.")
-        return self
-
-    def persist(self) -> Self:
-        logger.warning("Redshift does not support persist. Ignoring persist() call.")
-        return self

--- a/sqlframe/spark/dataframe.py
+++ b/sqlframe/spark/dataframe.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import sys
 import typing as t
 
 from sqlframe.base.dataframe import (
@@ -9,17 +8,12 @@ from sqlframe.base.dataframe import (
     _BaseDataFrameNaFunctions,
     _BaseDataFrameStatFunctions,
 )
+from sqlframe.base.mixins.dataframe_mixins import NoCachePersistSupportMixin
 from sqlframe.spark.group import SparkGroupedData
-
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
 
 if t.TYPE_CHECKING:
     from sqlframe.spark.readwriter import SparkDataFrameWriter
     from sqlframe.spark.session import SparkSession
-
 
 logger = logging.getLogger(__name__)
 
@@ -33,22 +27,15 @@ class SparkDataFrameStatFunctions(_BaseDataFrameStatFunctions["SparkDataFrame"])
 
 
 class SparkDataFrame(
+    NoCachePersistSupportMixin,
     _BaseDataFrame[
         "SparkSession",
         "SparkDataFrameWriter",
         "SparkDataFrameNaFunctions",
         "SparkDataFrameStatFunctions",
         "SparkGroupedData",
-    ]
+    ],
 ):
     _na = SparkDataFrameNaFunctions
     _stat = SparkDataFrameStatFunctions
     _group_data = SparkGroupedData
-
-    def cache(self) -> Self:
-        logger.warning("Spark does not support caching. Ignoring cache() call.")
-        return self
-
-    def persist(self) -> Self:
-        logger.warning("Spark does not support persist. Ignoring persist() call.")
-        return self

--- a/tests/integration/engines/bigquery/test_bigquery_dataframe.py
+++ b/tests/integration/engines/bigquery/test_bigquery_dataframe.py
@@ -1,0 +1,80 @@
+import datetime
+
+import pytest
+
+from sqlframe.base.types import Row
+from sqlframe.bigquery import BigQueryDataFrame, BigQuerySession
+
+pytest_plugins = ["tests.integration.fixtures"]
+pytestmark = [
+    pytest.mark.bigquery,
+    pytest.mark.xdist_group("bigquery_tests"),
+]
+
+
+def test_print_schema_basic(bigquery_employee: BigQueryDataFrame, capsys):
+    bigquery_employee.printSchema()
+    captured = capsys.readouterr()
+    assert (
+        captured.out.strip()
+        == """
+root
+ |-- employee_id: int64 (nullable = true)
+ |-- fname: string (nullable = true)
+ |-- lname: string (nullable = true)
+ |-- age: int64 (nullable = true)
+ |-- store_id: int64 (nullable = true)""".strip()
+    )
+
+
+def test_print_schema_nested(bigquery_session: BigQuerySession, capsys):
+    df = bigquery_session.createDataFrame(
+        [
+            (
+                1,
+                2.0,
+                "foo",
+                [Row(a=1, b=2)],
+                [1, 2, 3],
+                Row(a=1),
+                datetime.date(2022, 1, 1),
+                datetime.datetime(2022, 1, 1, 0, 0, 0),
+                datetime.datetime(2022, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc),
+                True,
+            )
+        ],
+        [
+            "bigint_col",
+            "double_col",
+            "string_col",
+            "array_struct_a_bigint_b_bigint__",
+            "array_bigint__col",
+            "struct_a_bigint__col",
+            "date_col",
+            "timestamp_col",
+            "timestamptz_col",
+            "boolean_col",
+        ],
+    )
+    df.printSchema()
+    captured = capsys.readouterr()
+    assert (
+        captured.out.strip()
+        == """
+root
+ |-- bigint_col: int64 (nullable = true)
+ |-- double_col: float64 (nullable = true)
+ |-- string_col: string (nullable = true)
+ |-- array_struct_a_bigint_b_bigint__: array<struct<a int64, b int64>> (nullable = false)
+ |    |-- element: struct<a int64, b int64> (nullable = true)
+ |    |    |-- a: int64 (nullable = true)
+ |    |    |-- b: int64 (nullable = true)
+ |-- array_bigint__col: array<int64> (nullable = false)
+ |    |-- element: int64 (nullable = true)
+ |-- struct_a_bigint__col: struct<a int64> (nullable = true)
+ |    |-- a: int64 (nullable = true)
+ |-- date_col: date (nullable = true)
+ |-- timestamp_col: datetime (nullable = true)
+ |-- timestamptz_col: timestamp (nullable = true)
+ |-- boolean_col: bool (nullable = true)""".strip()
+    )

--- a/tests/integration/engines/snowflake/test_snowflake_dataframe.py
+++ b/tests/integration/engines/snowflake/test_snowflake_dataframe.py
@@ -1,0 +1,85 @@
+import datetime
+
+import pytest
+
+from sqlframe.base.types import Row
+from sqlframe.bigquery import BigQueryDataFrame, BigQuerySession
+
+pytest_plugins = ["tests.integration.fixtures"]
+pytestmark = [
+    pytest.mark.snowflake,
+    pytest.mark.xdist_group("snowflake_tests"),
+]
+
+
+def test_print_schema_basic(snowflake_employee: BigQueryDataFrame, capsys):
+    snowflake_employee.printSchema()
+    captured = capsys.readouterr()
+    assert (
+        captured.out.strip()
+        == """
+root
+ |-- EMPLOYEE_ID: decimal(38, 0) (nullable = true)
+ |-- FNAME: varchar(16777216) (nullable = true)
+ |-- LNAME: varchar(16777216) (nullable = true)
+ |-- AGE: decimal(38, 0) (nullable = true)
+ |-- STORE_ID: decimal(38, 0) (nullable = true)""".strip()
+    )
+
+
+def test_print_schema_nested(snowflake_session: BigQuerySession, capsys):
+    df = snowflake_session.createDataFrame(
+        [
+            (
+                1,
+                2.0,
+                "foo",
+                {"a": 1},
+                [Row(a=1, b=2)],
+                [1, 2, 3],
+                Row(a=1),
+                datetime.date(2022, 1, 1),
+                datetime.datetime(2022, 1, 1, 0, 0, 0),
+                datetime.datetime(2022, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc),
+                True,
+            )
+        ],
+        [
+            "bigint_col",
+            "double_col",
+            "string_col",
+            "map_string_bigint__col",
+            "array_struct_a_bigint_b_bigint__",
+            "array_bigint__col",
+            "struct_a_bigint__col",
+            "date_col",
+            "timestamp_col",
+            "timestamptz_col",
+            "boolean_col",
+        ],
+    )
+    df.printSchema()
+    captured = capsys.readouterr()
+    assert (
+        captured.out.strip()
+        == """
+root
+ |-- BIGINT_COL: decimal(38, 0) (nullable = true)
+ |-- DOUBLE_COL: float (nullable = true)
+ |-- STRING_COL: varchar(16777216) (nullable = true)
+ |-- MAP_STRING_BIGINT__COL: map(varchar(16777216), decimal(38, 0)) (nullable = true)
+ |    |-- key: varchar(16777216) (nullable = true)
+ |    |-- value: decimal(38, 0) (nullable = true)
+ |-- ARRAY_STRUCT_A_BIGINT_B_BIGINT__: array(object(a decimal(38, 0), b decimal(38, 0))) (nullable = true)
+ |    |-- element: object(a decimal(38, 0), b decimal(38, 0)) (nullable = true)
+ |    |    |-- A: decimal(38, 0) (nullable = true)
+ |    |    |-- B: decimal(38, 0) (nullable = true)
+ |-- ARRAY_BIGINT__COL: array(decimal(38, 0)) (nullable = true)
+ |    |-- element: decimal(38, 0) (nullable = true)
+ |-- STRUCT_A_BIGINT__COL: object(a decimal(38, 0)) (nullable = true)
+ |    |-- A: decimal(38, 0) (nullable = true)
+ |-- DATE_COL: date (nullable = true)
+ |-- TIMESTAMP_COL: timestampntz(9) (nullable = true)
+ |-- TIMESTAMPTZ_COL: timestamptz(9) (nullable = true)
+ |-- BOOLEAN_COL: boolean (nullable = true)""".strip()
+    )


### PR DESCRIPTION
Expands on https://github.com/eakmanrq/sqlframe/pull/29 and adds support for BQ and Snowflake.

Now all engines with a connection can get their current data types. 