### PR TITLE
feat: no longer optimize by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ df = (
 )
 ```
 ```python
->>> df.sql()
+>>> df.sql(optimize=True)
 WITH `t94228` AS (
   SELECT
     `natality`.`year` AS `year`,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,7 +7,7 @@ This configuration is ideal if you aim to use the PySpark DataFrame API as if ru
 
 This configuration can be changed to make SQLFrame feel more like a native DataFrame API for the engine you are using.
 
-Example: Using BigQuery
+Example: Using BigQuery to Change Default Behavior
 
 ```python
 from sqlframe.bigquery import BigQuerySession
@@ -52,7 +52,9 @@ SELECT CAST(`a3`.`a` AS BIGINT) AS `a`, CAST(`a3`.`b` AS BIGINT) AS `b` FROM VAL
 
 ### Optimized
 
-Optimized SQL is SQL that has been processed by SQLGlot's optimizer. For complex queries this will significantly reduce the number of CTEs produced and remove extra unused columns. Defaults to `True`.
+Optimized SQL is SQL that has been processed by SQLGlot's optimizer. 
+For complex queries this will significantly reduce the number of CTEs produced and remove extra unused columns. 
+Defaults to `False`.
 
 ```python
 from sqlframe.bigquery import BigQuerySession
@@ -201,7 +203,9 @@ LIMIT 5
 
 ### Override Dialect
 
-The dialect of the generated SQL will be based on the session's dialect. However, you can override the dialect by passing a string to the `dialect` parameter. This is useful when you want to generate SQL for a different database.
+The dialect of the generated SQL will be based on the session's output dialect. 
+However, you can override the dialect by passing a string to the `dialect` parameter. 
+This is useful when you want to generate SQL for a different database.
 
 ```python
 # create session and `df` like normal

--- a/sqlframe/base/dataframe.py
+++ b/sqlframe/base/dataframe.py
@@ -536,9 +536,6 @@ class _BaseDataFrame(t.Generic[SESSION, WRITER, NA, STAT, GROUP_DATA]):
             )
         return [col]
 
-    def _sql(self) -> str:
-        return self.session._to_sql(self.expression, dialect=self.session.execution_dialect)
-
     def _get_expressions(
         self,
         optimize: bool = True,


### PR DESCRIPTION
When using `optimize`, invalid SQL can be generated. Therefore SQLFrame will now start favoring accurate SQL over readable by default but let user pass in `optimize=True` if they would like the optimized result. 