### PR TITLE
chore: fix example bq path

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ from sqlframe.bigquery import functions as F
 from sqlframe.bigquery import Window
 
 session = BigQuerySession()
-table_path = "bigquery-public-data.samples.natality"
+table_path = '"bigquery-public-data".samples.natality'
 # Top 5 years with the greatest year-over-year % change in new families with single child
 df = (
     session.table(table_path)

--- a/blogs/add_chatgpt_support.md
+++ b/blogs/add_chatgpt_support.md
@@ -47,7 +47,7 @@ from sqlframe.bigquery import functions as F
 from sqlframe.bigquery import Window
 
 session = BigQuerySession()
-table_path = "bigquery-public-data.samples.natality"
+table_path = '"bigquery-public-data".samples.natality'
 # Top 5 years with the greatest year-over-year % change in new families with single child
 df = (
     session.table(table_path)

--- a/blogs/sqlframe_universal_dataframe_api.md
+++ b/blogs/sqlframe_universal_dataframe_api.md
@@ -39,7 +39,7 @@ from sqlframe.bigquery import Window
 
 # Unique to SQLFrame: Ability to connect directly to BigQuery
 session = BigQuerySession()
-table_path = "bigquery-public-data.samples.natality"
+table_path = '"bigquery-public-data".samples.natality'
 # Get the top 5 years with the greatest year-over-year % change in new families with a single child
 df = (
     session.table(table_path)

--- a/docs/bigquery.md
+++ b/docs/bigquery.md
@@ -72,7 +72,7 @@ from sqlframe.bigquery import functions as F
 
 session = BigQuerySession(default_dataset="sqlframe.db1")
 (
-    session.table("bigquery-public-data.samples.natality")
+    session.table('"bigquery-public-data".samples.natality')
     .select(F.call_function("FARM_FINGERPRINT", F.col("source")).alias("source_hash"))
     .show()
 )
@@ -86,7 +86,7 @@ from sqlframe.bigquery import functions as F
 from sqlframe.bigquery import Window
 
 session = BigQuerySession(default_dataset="sqlframe.db1")
-table_path = "bigquery-public-data.samples.natality"
+table_path = '"bigquery-public-data".samples.natality'
 # Get columns in the table
 print(session.catalog.listColumns(table_path))
 # Get the top 5 years with the greatest year-over-year % change in new families with a single child

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,7 +62,7 @@ from sqlframe.bigquery import functions as F
 from sqlframe.bigquery import Window
 
 session = BigQuerySession()
-table_path = "bigquery-public-data.samples.natality"
+table_path = '"bigquery-public-data".samples.natality'
 # Top 5 years with the greatest year-over-year % change in new families with single child
 df = (
     session.table(table_path)


### PR DESCRIPTION
Now that inputs are parsed by default in spark format the catalog name needs to be quoted with double quotes (spark format) since it contains hyphens. 