### PR TITLE
chore: adjust time zone approach back to legacy

### DIFF
--- a/sqlframe/duckdb/session.py
+++ b/sqlframe/duckdb/session.py
@@ -52,6 +52,10 @@ class DuckDBSession(
             super().__init__(conn, *args, **kwargs)
             self._last_result = None
 
+    @cached_property
+    def _cur(self) -> DuckDBPyConnection:  # type: ignore
+        return self._conn
+
     @classmethod
     def _try_get_map(cls, value: t.Any) -> t.Optional[t.Dict[str, t.Any]]:
         if value and isinstance(value, dict):

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -117,8 +117,11 @@ def spark_session(pyspark_session: PySparkSession) -> SparkSession:
 
 @pytest.fixture(scope="function")
 def duckdb_session() -> DuckDBSession:
-    connection = duckdb.connect(config={"TimeZone": "UTC"})
-    return DuckDBSession(conn=connection)
+    connector = duckdb.connect()
+    connector.execute("set TimeZone = 'UTC'")
+    connector.execute("SELECT * FROM duckdb_settings() WHERE name = 'TimeZone'")
+    assert connector.fetchone()[1] == "UTC"  # type: ignore
+    return DuckDBSession(conn=connector)
 
 
 @pytest.fixture

--- a/tests/integration/engines/duck/test_duckdb_catalog.py
+++ b/tests/integration/engines/duck/test_duckdb_catalog.py
@@ -8,7 +8,10 @@ from sqlframe.duckdb.session import DuckDBSession
 def duckdb_session() -> DuckDBSession:
     import duckdb
 
-    connector = duckdb.connect(config={"TimeZone": "UTC"})
+    connector = duckdb.connect()
+    connector.execute("set TimeZone = 'UTC'")
+    connector.execute("SELECT * FROM duckdb_settings() WHERE name = 'TimeZone'")
+    assert connector.fetchone()[1] == "UTC"  # type: ignore
     session = DuckDBSession(connector)
     session._execute('''ATTACH ':memory:' AS "default"''')
     session._execute('''ATTACH ':memory:' AS "catalog1"''')

--- a/tests/integration/engines/test_int_functions.py
+++ b/tests/integration/engines/test_int_functions.py
@@ -18,7 +18,7 @@ from sqlframe.base.util import (
     get_func_from_session as get_func_from_session_without_fallback,
 )
 from sqlframe.bigquery import BigQuerySession
-from sqlframe.duckdb import DuckDBSession
+from sqlframe.duckdb import DuckDBCatalog, DuckDBSession
 from sqlframe.postgres import PostgresDataFrame, PostgresSession
 from sqlframe.snowflake import SnowflakeSession
 from sqlframe.spark.session import SparkSession


### PR DESCRIPTION
This was supposed to be fixed in 1.1.0: https://github.com/duckdb/duckdb/pull/12790

It is unreliable though. Some CI tests would fail with `ERROR tests/integration/engines/duck/test_duckdb_catalog.py::test_set_current_catalog - duckdb.duckdb.InvalidInputException: Invalid Input Error: To set the TimeZone setting, the icu extension needs to be loaded. But it could not be autoloaded.`. Reverting back to old apporach. 

It seems like with 1.1.0 the settings put on a connection are not transferred to a cursor so also have to make sure that the connection is used insead of the new cursor object. 