### PR TITLE
fix: added missing eqNullSafe column method

### DIFF
--- a/sqlframe/base/column.py
+++ b/sqlframe/base/column.py
@@ -338,6 +338,9 @@ class Column:
         new_expression = exp.Not(this=exp.Is(this=self.column_expression, expression=exp.Null()))
         return Column(new_expression)
 
+    def eqNullSafe(self, other: ColumnOrLiteral) -> Column:
+        return self.binary_op(exp.NullSafeEQ, other)
+    
     def cast(
         self,
         dataType: t.Union[str, DataType, exp.DataType, exp.DataType.Type],

--- a/tests/integration/test_int_dataframe.py
+++ b/tests/integration/test_int_dataframe.py
@@ -231,6 +231,18 @@ def test_where_clause_single(
     compare_frames(df_employee, dfs_employee)
 
 
+def test_where_clause_eq_nullsafe(
+    pyspark_employee: PySparkDataFrame,
+    get_df: t.Callable[[str], _BaseDataFrame],
+    compare_frames: t.Callable,
+):
+    employee = get_df("employee")
+    df_employee = pyspark_employee.where(F.col("age").eqNullSafe(F.lit(37)))
+    dfs_employee = employee.where(SF.col("age") == SF.lit(37))
+    compare_frames(df_employee, dfs_employee)
+
+
+
 def test_where_clause_multiple_and(
     pyspark_employee: PySparkDataFrame,
     get_df: t.Callable[[str], _BaseDataFrame],


### PR DESCRIPTION
Added `eqNullSafe` method on column ([pyspark docs on this method](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.Column.eqNullSafe.html))