### PR TITLE
fix: remove convert to leaf before showing

### DIFF
--- a/sqlframe/base/dataframe.py
+++ b/sqlframe/base/dataframe.py
@@ -1624,9 +1624,7 @@ class _BaseDataFrame(t.Generic[SESSION, WRITER, NA, STAT, GROUP_DATA]):
             raise NotImplementedError("Vertical show is not yet supported")
         if truncate:
             logger.warning("Truncate is ignored so full results will be displayed")
-        # Make sure that the limit we add doesn't affect the results
-        df = self._convert_leaf_to_cte()
-        result = df.limit(n).collect()
+        result = self.limit(n).collect()
         table = PrettyTable()
         if row := seq_get(result, 0):
             table.field_names = row._unique_field_names

--- a/tests/fixtures/issue_219.csv
+++ b/tests/fixtures/issue_219.csv
@@ -1,0 +1,10 @@
+kind,price,make
+standard,30,emcsquare
+capsule,40,emcsquare
+candle,10,emcsquare
+standard,20,maxwells
+capsule,45,maxwells
+candle,11,maxwells
+standard,90,voltaires
+capsule,95,voltaires
+candle,80,voltaires

--- a/tests/integration/engines/duck/test_duckdb_reader.py
+++ b/tests/integration/engines/duck/test_duckdb_reader.py
@@ -1,5 +1,6 @@
 from sqlframe.base.types import Row
 from sqlframe.duckdb import DuckDBSession
+from sqlframe.duckdb import functions as F
 
 pytest_plugins = ["tests.common_fixtures"]
 
@@ -114,3 +115,10 @@ def test_employee_delta(duckdb_session: DuckDBSession):
         ),
         Row(**{"employee_id": 5, "fname": "Hugo", "lname": "Reyes", "age": 29, "store_id": 100}),
     ]
+
+
+def test_issue_219(duckdb_session: DuckDBSession):
+    df1 = duckdb_session.read.csv("tests/fixtures/issue_219.csv")
+    df2 = df1.groupBy("kind", "make").agg(F.min("price"))
+    # Just making sure this doesn't raise like it did before
+    df2.show()


### PR DESCRIPTION
Fixes: https://github.com/eakmanrq/sqlframe/issues/219

Since limit is last in the order of operations it should be fine to apply it directly to the query. 