### PR TITLE
feat!: accept pd.DataFrame in session.createDataFrame

### DIFF
--- a/sqlframe/base/session.py
+++ b/sqlframe/base/session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import datetime
 import logging
 import sys
@@ -208,13 +209,16 @@ class _BaseSession(t.Generic[CATALOG, READER, WRITER, DF, TABLE, CONN, UDF_REGIS
 
     def createDataFrame(
         self,
-        data: t.Sequence[
-            t.Union[
-                t.Dict[str, ColumnLiterals],
-                t.List[ColumnLiterals],
-                t.Tuple[ColumnLiterals, ...],
-                ColumnLiterals,
-            ]
+        data: t.Union[
+            t.Sequence[
+                t.Union[
+                    t.Dict[str, ColumnLiterals],
+                    t.List[ColumnLiterals],
+                    t.Tuple[ColumnLiterals, ...],
+                    ColumnLiterals,
+                ],
+            ],
+            pd.DataFrame,
         ],
         schema: t.Optional[SchemaInput] = None,
         samplingRatio: t.Optional[float] = None,
@@ -235,11 +239,18 @@ class _BaseSession(t.Generic[CATALOG, READER, WRITER, DF, TABLE, CONN, UDF_REGIS
         ):
             raise NotImplementedError("Only schema of either list or string of list supported")
 
+        with contextlib.suppress(ImportError):
+            from pandas import DataFrame as pd_DataFrame
+
+            if isinstance(data, pd_DataFrame):
+                data = data.to_dict("records")  # type: ignore
+
         column_mapping: t.Mapping[str, t.Optional[exp.DataType]]
         if schema is not None:
             column_mapping = get_column_mapping_from_schema_input(
                 schema, dialect=self.input_dialect
             )
+
         elif data:
             if isinstance(data[0], Row):
                 column_mapping = {col_name.strip(): None for col_name in data[0].__fields__}
@@ -381,7 +392,8 @@ class _BaseSession(t.Generic[CATALOG, READER, WRITER, DF, TABLE, CONN, UDF_REGIS
         dialect = Dialect.get_or_raise(dialect or self.input_dialect)
         expression = (
             sqlglot.parse_one(
-                normalize_string(sqlQuery, from_dialect=dialect, is_query=True), read=dialect
+                normalize_string(sqlQuery, from_dialect=dialect, is_query=True),
+                read=dialect,
             )
             if isinstance(sqlQuery, str)
             else sqlQuery

--- a/tests/integration/test_int_dataframe.py
+++ b/tests/integration/test_int_dataframe.py
@@ -38,7 +38,9 @@ def test_dataframe_from_pandas(
     employee = get_df("employee")
     compare_frames(
         pyspark_employee,
-        employee.session.createDataFrame(pyspark_employee.toPandas()),
+        employee.session.createDataFrame(
+            pyspark_employee.toPandas(), schema=pyspark_employee.schema.simpleString()
+        ),
     )
 
 

--- a/tests/integration/test_int_dataframe.py
+++ b/tests/integration/test_int_dataframe.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
+import pandas as pd
 import pytest
 from _pytest.fixtures import FixtureRequest
 from pyspark.sql import DataFrame as PySparkDataFrame
@@ -27,6 +28,18 @@ def test_empty_df(
     df_empty = pyspark_employee.sparkSession.createDataFrame([], "cola int, colb int")
     dfs_empty = get_df("employee").session.createDataFrame([], "cola int, colb int")
     compare_frames(df_empty, dfs_empty, no_empty=False)
+
+
+def test_dataframe_from_pandas(
+    pyspark_employee: PySparkDataFrame,
+    get_df: t.Callable[[str], BaseDataFrame],
+    compare_frames: t.Callable,
+):
+    employee = get_df("employee")
+    compare_frames(
+        pyspark_employee,
+        employee.session.createDataFrame(pyspark_employee.toPandas()),
+    )
 
 
 def test_simple_select(


### PR DESCRIPTION
This PR adds the possibility to create a DataFrame from a `pd.DataFrame` using `session.createDataFrame`, further mimicking pyspark's behaviour"