### PR TITLE
feat: add regexp support except snowflake

### DIFF
--- a/docs/bigquery.md
+++ b/docs/bigquery.md
@@ -449,6 +449,7 @@ See something that you would like to see supported? [Open an issue](https://gith
 * [radians](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.radians.html)
 * [rand](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.rand.html)
 * [rank](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.rank.html)
+* [regexp](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.regexp.html)
 * [regexp_extract](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.regexp_extract.html)
     * Single capture group is supported
 * [regexp_like](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.regexp_like.html)

--- a/docs/duckdb.md
+++ b/docs/duckdb.md
@@ -417,6 +417,7 @@ See something that you would like to see supported? [Open an issue](https://gith
 * [radians](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.radians.html)
 * [rand](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.rand.html)
 * [rank](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.rank.html)
+* [regexp](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.regexp.html)
 * [regexp_extract](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.regexp_extract.html)
 * [regexp_like](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.regexp_like.html)
 * [regexp_replace](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.regexp_replace.html)

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -412,6 +412,7 @@ See something that you would like to see supported? [Open an issue](https://gith
 * [radians](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.radians.html)
 * [rand](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.rand.html)
 * [rank](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.rank.html)
+* [regexp](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.regexp.html)
 * [regexp_like](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.regexp_like.html)
 * [regexp_replace](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.regexp_replace.html)
 * [repeat](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.repeat.html)

--- a/sqlframe/base/function_alternatives.py
+++ b/sqlframe/base/function_alternatives.py
@@ -1408,6 +1408,14 @@ def regexp_replace_global_option(
     )
 
 
+def regexp_with_matches(str: ColumnOrName, regexp: ColumnOrName) -> Column:
+    return Column.invoke_anonymous_function(str, "REGEXP_MATCHES", regexp)
+
+
+def regexp_with_contains(str: ColumnOrName, regexp: ColumnOrName) -> Column:
+    return Column.invoke_anonymous_function(str, "REGEXP_CONTAINS", regexp)
+
+
 def degrees_bgutil(col: ColumnOrName) -> Column:
     return Column(
         expression.Anonymous(


### PR DESCRIPTION
Resolves: https://github.com/eakmanrq/sqlframe/issues/259

This returns false which is confusing to me:
```
SELECT
  REGEXP_LIKE('1a 2b 14m', '1') AS "REGEXP__STR__";
```

So just excluded Snowflake support for now. Might just be late and will make more sense to me another time. 