### PR TITLE
feat: support pyspark display name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,17 +13,8 @@ fast-test:
 local-test:
 	pytest -n auto -m "fast or local"
 
-bigquery-test:
-	pytest -n auto -m "bigquery"
-
-duckdb-test:
-	pytest -n auto -m "duckdb"
-
-snowflake-test:
-	pytest -n auto -m "snowflake"
-
-databricks-test:
-	pytest -n auto -m "databricks"
+%-test:
+	pytest -n auto -m "${*}"
 
 style:
 	pre-commit run --all-files

--- a/sqlframe/base/column.py
+++ b/sqlframe/base/column.py
@@ -291,6 +291,7 @@ class Column:
             this=self.column_expression,
             alias=alias.this if isinstance(alias, exp.Column) else alias,
         )
+        new_expression._meta = {"display_name": name, **(new_expression._meta or {})}
         return Column(new_expression)
 
     def asc(self) -> Column:

--- a/sqlframe/base/functions.py
+++ b/sqlframe/base/functions.py
@@ -39,11 +39,19 @@ def col(column_name: t.Union[ColumnOrName, t.Any]) -> Column:
 
     dialect = _BaseSession().input_dialect
     if isinstance(column_name, str):
-        return Column(
-            expression.to_column(column_name, dialect=dialect).transform(
-                dialect.normalize_identifier
-            )
+        col_expression = expression.to_column(column_name, dialect=dialect).transform(
+            dialect.normalize_identifier
         )
+        case_sensitive_expression = expression.to_column(column_name, dialect=dialect)
+        if not isinstance(
+            case_sensitive_expression, (expression.Star, expression.Literal, expression.Null)
+        ):
+            col_expression._meta = {
+                "display_name": case_sensitive_expression.this.this,
+                **(col_expression._meta or {}),
+            }
+
+        return Column(col_expression)
     return Column(column_name)
 
 

--- a/sqlframe/base/session.py
+++ b/sqlframe/base/session.py
@@ -507,9 +507,14 @@ class _BaseSession(t.Generic[CATALOG, READER, WRITER, DF, TABLE, CONN, UDF_REGIS
         result = self._cur.fetchall()
         if not self._cur.description:
             return []
+        case_sensitive_cols = []
+        for col in self._cur.description:
+            col_id = exp.parse_identifier(col[0], dialect=self.execution_dialect)
+            col_id._meta = {"case_sensitive": True, **(col_id._meta or {})}
+            case_sensitive_cols.append(col_id)
         columns = [
-            normalize_string(x[0], from_dialect="execution", to_dialect="output", is_column=True)
-            for x in self._cur.description
+            normalize_string(x, from_dialect="execution", to_dialect="output")
+            for x in case_sensitive_cols
         ]
         return [self._to_row(columns, row) for row in result]
 

--- a/sqlframe/spark/session.py
+++ b/sqlframe/spark/session.py
@@ -79,17 +79,18 @@ class SparkSession(
         if skip_rows:
             return []
         assert self._last_df is not None
-        return [
-            Row(
-                **{
-                    normalize_string(
-                        k, from_dialect="execution", to_dialect="output", is_column=True
-                    ): v
-                    for k, v in row.asDict().items()
-                }
-            )
-            for row in self._last_df.collect()
-        ]
+        results = []
+        for row in self._last_df.collect():
+            rows_normalized = {}
+            for k, v in row.asDict().items():
+                col_id = exp.parse_identifier(k, dialect=self.execution_dialect)
+                col_id._meta = {"case_sensitive": True, **(col_id._meta or {})}
+                col_name = normalize_string(
+                    col_id, from_dialect="execution", to_dialect="output", is_column=True
+                )
+                rows_normalized[col_name] = v
+            results.append(Row(**rows_normalized))
+        return results
 
     def _execute(self, sql: str) -> None:
         self._last_df = self.spark_session.sql(sql)

--- a/tests/integration/engines/test_int_functions.py
+++ b/tests/integration/engines/test_int_functions.py
@@ -241,7 +241,7 @@ def test_alias(get_session_and_func):
             DatabricksSession,
         ),
     ):
-        assert space_result == "`a space in new name`"
+        assert space_result == "`A Space In New Name`"
     else:
         assert space_result == "A Space In New Name"
 

--- a/tests/unit/standalone/test_dataframe.py
+++ b/tests/unit/standalone/test_dataframe.py
@@ -55,7 +55,7 @@ def test_with_column_duplicate_alias(standalone_employee: StandaloneDataFrame):
     # Make sure that the new columns is added with an alias to `fname`
     assert (
         df.sql(pretty=False)
-        == "SELECT `a1`.`employee_id` AS `employee_id`, CAST(`a1`.`age` AS STRING) AS `fname`, CAST(`a1`.`lname` AS STRING) AS `lname`, `a1`.`age` AS `age`, `a1`.`store_id` AS `store_id` FROM VALUES (1, 'Jack', 'Shephard', 37, 1), (2, 'John', 'Locke', 65, 1), (3, 'Kate', 'Austen', 37, 2), (4, 'Claire', 'Littleton', 27, 2), (5, 'Hugo', 'Reyes', 29, 100) AS `a1`(`employee_id`, `fname`, `lname`, `age`, `store_id`)"
+        == "SELECT `a1`.`employee_id` AS `employee_id`, CAST(`a1`.`age` AS STRING) AS `fName`, CAST(`a1`.`lname` AS STRING) AS `lname`, `a1`.`age` AS `age`, `a1`.`store_id` AS `store_id` FROM VALUES (1, 'Jack', 'Shephard', 37, 1), (2, 'John', 'Locke', 65, 1), (3, 'Kate', 'Austen', 37, 2), (4, 'Claire', 'Littleton', 27, 2), (5, 'Hugo', 'Reyes', 29, 100) AS `a1`(`employee_id`, `fname`, `lname`, `age`, `store_id`)"
     )
 
 
@@ -86,7 +86,7 @@ def test_transform(standalone_employee: StandaloneDataFrame):
     df = standalone_employee.transform(cast_all_to_int).transform(sort_columns_asc)
     assert df.columns == ["age", "employee_id", "fname", "lname", "store_id"]
     assert df.sql(pretty=False, optimize=False).endswith(  # type: ignore
-        "SELECT CAST(`employee_id` AS INT) AS `employee_id`, CAST(`fname` AS INT) AS `fname`, CAST(`lname` AS INT) AS `lname`, CAST(`age` AS INT) AS `age`, CAST(`store_id` AS INT) AS `store_id` FROM `t51718876`) SELECT `age`, `employee_id`, `fname`, `lname`, `store_id` FROM `t16881256`"
+        "SELECT CAST(`employee_id` AS INT) AS `employee_id`, CAST(`fname` AS INT) AS `fname`, CAST(`lname` AS INT) AS `lname`, CAST(`age` AS INT) AS `age`, CAST(`store_id` AS INT) AS `store_id` FROM `t51718876`) SELECT `age` AS `age`, `employee_id` AS `employee_id`, `fname` AS `fname`, `lname` AS `lname`, `store_id` AS `store_id` FROM `t16881256`"
     )
 
 

--- a/tests/unit/standalone/test_dataframe_writer.py
+++ b/tests/unit/standalone/test_dataframe_writer.py
@@ -104,4 +104,4 @@ def test_saveAsTable_cache(standalone_employee: StandaloneDataFrame, compare_sql
 def test_quotes(standalone_session: StandaloneSession, compare_sql: t.Callable):
     standalone_session.catalog.add_table("`Test`", {"`ID`": "STRING"})
     df = standalone_session.table("`Test`")
-    compare_sql(df.select(df["`ID`"]), ["SELECT `test`.`id` AS `id` FROM `test` AS `test`"])
+    compare_sql(df.select(df["`ID`"]), ["SELECT `test`.`id` AS `ID` FROM `test` AS `test`"])

--- a/tests/unit/standalone/test_session_case_sensitivity.py
+++ b/tests/unit/standalone/test_session_case_sensitivity.py
@@ -17,7 +17,7 @@ tests = [
         "test",
         {"name": "VARCHAR"},
         "name",
-        '''SELECT "TEST"."NAME" AS "NAME" FROM "TEST" AS "TEST"''',
+        '''SELECT "TEST"."NAME" AS "name" FROM "TEST" AS "TEST"''',
     ),
     (
         "Table has CS while column does not",
@@ -25,7 +25,7 @@ tests = [
         '"Test"',
         {"name": "VARCHAR"},
         "name",
-        '''SELECT "TEST"."NAME" AS "NAME" FROM "Test" AS "TEST"''',
+        '''SELECT "TEST"."NAME" AS "name" FROM "Test" AS "TEST"''',
     ),
     (
         "Column has CS while table does not",


### PR DESCRIPTION
Resolves: https://github.com/eakmanrq/sqlframe/issues/258

PySpark, by default, is case-insensitive. Meaning if I have a mixed case column that I create I can reference that throughout my DataFrame code with any case. The unique part is that the mixed case will show up in the result to the user. Therefore a SQL-way to think about this is that the case provided by the user is not included in the SQL logic until the final select and is used to alias the final select columns to the case-sensitivity provided. 

Therefore SQLFrame calls this the `display_name` and now matches this behavior. 