### PR TITLE
feat: add support for `ByteType`

### DIFF
--- a/docs/duckdb.md
+++ b/docs/duckdb.md
@@ -266,7 +266,7 @@ See something that you would like to see supported? [Open an issue](https://gith
 * [acos](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.acos.html)
 * [add_months](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.add_months.html)
 * [any_value](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.any_value.html)
-  * Always ignores nulls
+    * Always ignores nulls
 * [approxCountDistinct](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.approxCountDistinct.html)
 * [approx_count_distinct](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.approx_count_distinct.html)
 * [array](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.array.html)

--- a/sqlframe/base/util.py
+++ b/sqlframe/base/util.py
@@ -316,6 +316,7 @@ def sqlglot_to_spark(sqlglot_dtype: exp.DataType) -> types.DataType:
         exp.DataType.Type.INT: types.IntegerType,
         exp.DataType.Type.BIGINT: types.LongType,
         exp.DataType.Type.SMALLINT: types.ShortType,
+        exp.DataType.Type.TINYINT: types.ByteType,
         exp.DataType.Type.FLOAT: types.FloatType,
         exp.DataType.Type.DOUBLE: types.DoubleType,
         exp.DataType.Type.DECIMAL: types.DecimalType,

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -39,6 +39,7 @@ def test_quote_preserving_alias_or_name(expression: t.Union[exp.Column, exp.Alia
         ("INTEGER", types.IntegerType()),
         ("BIGINT", types.LongType()),
         ("SMALLINT", types.ShortType()),
+        ("TINYINT", types.ByteType()),
         ("FLOAT", types.FloatType()),
         ("DOUBLE", types.DoubleType()),
         ("BOOLEAN", types.BooleanType()),


### PR DESCRIPTION
# Description

Add support for converting to [`ByteType`](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.types.ByteType.html).

Documentation was already available in each backend/dialect.

Spotted on while trying to get schema in a narwhals test 😇

