### PR TITLE
feat: pass optional kwargs from `_BaseCatalog.add_table` to `sqlglot.MappingSchema.add_table`

### DIFF
--- a/sqlframe/base/catalog.py
+++ b/sqlframe/base/catalog.py
@@ -70,7 +70,10 @@ class _BaseCatalog(t.Generic[SESSION, DF]):
         }
 
     def add_table(
-        self, table: exp.Table | str, column_mapping: t.Optional[ColumnMapping] = None
+        self,
+        table: exp.Table | str,
+        column_mapping: t.Optional[ColumnMapping] = None,
+        **kwargs: t.Any,
     ) -> None:
         # TODO: Making this an update or add
         table = self.ensure_table(table)
@@ -100,7 +103,7 @@ class _BaseCatalog(t.Generic[SESSION, DF]):
             if column.this.quoted:
                 self._quoted_columns[table].append(column.this.name)
 
-        self._schema.add_table(table, column_mapping, dialect=self.session.input_dialect)
+        self._schema.add_table(table, column_mapping, dialect=self.session.input_dialect, **kwargs)
 
     def getDatabase(self, dbName: str) -> Database:
         """Get the database with the specified name.

--- a/sqlframe/base/catalog.py
+++ b/sqlframe/base/catalog.py
@@ -79,7 +79,7 @@ class _BaseCatalog(t.Generic[SESSION, DF]):
         table = self.ensure_table(table)
         if self._schema.find(table):
             return
-        if not column_mapping:
+        if column_mapping is None:
             try:
                 column_mapping = {
                     normalize_string(


### PR DESCRIPTION
I also did [this](https://github.com/eakmanrq/sqlframe/commit/30bc06603971a5815d54d6e16caf2a5e6db31621), but keep me honest on whether you want that, I'd be happy to remove that if need be. I had just encountered it when I passed a dummy table with no columns to `add_table`. You could reason that a table with no columns is worthless (and you'd be right), but I _think_ the intention of that truthy check was assuming None.

closes #313 