### PR TITLE
fix: remove deprecated numpy check

### DIFF
--- a/sqlframe/base/util.py
+++ b/sqlframe/base/util.py
@@ -279,15 +279,6 @@ def verify_openai_installed():
         )
 
 
-def verify_numpy_installed():
-    try:
-        import numpy  # noqa
-    except ImportError:
-        raise ImportError(
-            """Numpy is required for this functionality. `pip install "sqlframe[pandas]"` (also include your engine if needed) to install pandas/numpy."""
-        )
-
-
 def quote_preserving_alias_or_name(col: t.Union[exp.Column, exp.Alias]) -> str:
     from sqlframe.base.session import _BaseSession
 

--- a/sqlframe/duckdb/session.py
+++ b/sqlframe/duckdb/session.py
@@ -4,7 +4,7 @@ import typing as t
 from functools import cached_property
 
 from sqlframe.base.session import _BaseSession
-from sqlframe.base.util import soundex, verify_numpy_installed
+from sqlframe.base.util import soundex
 from sqlframe.duckdb.catalog import DuckDBCatalog
 from sqlframe.duckdb.dataframe import DuckDBDataFrame
 from sqlframe.duckdb.readwriter import (
@@ -46,8 +46,6 @@ class DuckDBSession(
         if not hasattr(self, "_conn"):
             conn = conn or duckdb.connect()
             try:
-                # Creating a function requires numpy to be installed so if they don't have it, we'll just skip it
-                verify_numpy_installed()
                 conn.create_function("SOUNDEX", lambda x: soundex(x), return_type=VARCHAR)
             except ImportError:
                 pass


### PR DESCRIPTION
I believe this was old code that isn't needed anymore. Tested locally removing numpy and soundex worked fine without it. 