### PR TITLE
Typing for DataFrame-Operations

### DIFF
--- a/sqlframe/base/dataframe.py
+++ b/sqlframe/base/dataframe.py
@@ -1730,8 +1730,8 @@ class BaseDataFrame(t.Generic[SESSION, WRITER, NA, STAT, GROUP_DATA]):
     @operation(Operation.SELECT)
     def unpivot(
         self,
-        ids: t.Union[ColumnOrName, t.List[ColumnOrName], t.Tuple[ColumnOrName, ...]],
-        values: t.Optional[t.Union[ColumnOrName, t.List[ColumnOrName], t.Tuple[ColumnOrName, ...]]],
+        ids: t.Union[ColumnOrName, t.Collection[ColumnOrName]],
+        values: t.Optional[t.Union[ColumnOrName, t.Collection[ColumnOrName]]],
         variableColumnName: str,
         valueColumnName: str,
     ) -> Self:

--- a/sqlframe/base/group.py
+++ b/sqlframe/base/group.py
@@ -16,6 +16,8 @@ else:
 # https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-groupby.html
 # https://stackoverflow.com/questions/37975227/what-is-the-difference-between-cube-rollup-and-groupby-operators
 class _BaseGroupedData(t.Generic[DF]):
+    last_op: Operation
+
     def __init__(
         self,
         df: DF,

--- a/sqlframe/base/mixins/dataframe_mixins.py
+++ b/sqlframe/base/mixins/dataframe_mixins.py
@@ -4,6 +4,9 @@ import typing as t
 
 from sqlglot import exp
 
+if t.TYPE_CHECKING:
+    from sqlframe.base._typing import StorageLevel
+
 from sqlframe.base.catalog import Column
 from sqlframe.base.dataframe import (
     GROUP_DATA,
@@ -28,7 +31,7 @@ class NoCachePersistSupportMixin(BaseDataFrame, t.Generic[SESSION, WRITER, NA, S
         logger.warning("This engine does not support caching. Ignoring cache() call.")
         return self
 
-    def persist(self) -> Self:
+    def persist(self, storageLevel: "StorageLevel" = "MEMORY_AND_DISK_SER") -> Self:
         logger.warning("This engine does not support persist. Ignoring persist() call.")
         return self
 

--- a/sqlframe/base/operations.py
+++ b/sqlframe/base/operations.py
@@ -77,10 +77,11 @@ def operation(
 
 
 # Here decorate a function (self: _BaseGroupedData[DF], *args, **kwargs) -> DF
-def group_operation(op: Operation) -> t.Callable[
-    [t.Callable[Concatenate[_BaseGroupedData[DF], P], DF]],
-    t.Callable[Concatenate[_BaseGroupedData[DF], P], DF],
-]:
+# Hence we work with t.Callable[Concatenate[_BaseGroupedData[DF], P], DF]
+# We simplify the parameters, as Pyright (used for VSCode autocomplete) doesn't unterstand this
+def group_operation(
+    op: Operation,
+) -> t.Callable[[t.Callable[P, DF]], t.Callable[P, DF]]:
     """
     Decorator used around DataFrame methods to indicate what type of operation is being performed from the
     ordered Operation enums. This is used to determine which operations should be performed on a CTE vs.
@@ -111,4 +112,4 @@ def group_operation(op: Operation) -> t.Callable[
         wrapper.__wrapped__ = func
         return wrapper
 
-    return decorator
+    return decorator  # type: ignore

--- a/sqlframe/base/window.py
+++ b/sqlframe/base/window.py
@@ -27,11 +27,11 @@ class Window:
     currentRow: int = 0
 
     @classmethod
-    def partitionBy(cls, *cols: t.Union[ColumnOrName, t.List[ColumnOrName]]) -> WindowSpec:
+    def partitionBy(cls, *cols: t.Union[ColumnOrName, t.Collection[ColumnOrName]]) -> WindowSpec:
         return WindowSpec().partitionBy(*cols)
 
     @classmethod
-    def orderBy(cls, *cols: t.Union[ColumnOrName, t.List[ColumnOrName]]) -> WindowSpec:
+    def orderBy(cls, *cols: t.Union[ColumnOrName, t.Collection[ColumnOrName]]) -> WindowSpec:
         return WindowSpec().orderBy(*cols)
 
     @classmethod
@@ -55,10 +55,10 @@ class WindowSpec:
 
         return self.expression.sql(dialect=_BaseSession().input_dialect, **kwargs)
 
-    def partitionBy(self, *cols: t.Union[ColumnOrName, t.List[ColumnOrName]]) -> WindowSpec:
+    def partitionBy(self, *cols: t.Union[ColumnOrName, t.Collection[ColumnOrName]]) -> WindowSpec:
         from sqlframe.base.column import Column
 
-        cols = flatten(cols) if isinstance(cols[0], (list, set, tuple)) else cols  # type: ignore
+        cols = flatten(cols) if isinstance(cols[0], t.Collection) else cols  # type: ignore
         expressions = [Column.ensure_col(x).expression for x in cols]  # type: ignore
         window_spec = self.copy()
         partition_by_expressions = window_spec.expression.args.get("partition_by", [])
@@ -66,10 +66,10 @@ class WindowSpec:
         window_spec.expression.set("partition_by", partition_by_expressions)
         return window_spec
 
-    def orderBy(self, *cols: t.Union[ColumnOrName, t.List[ColumnOrName]]) -> WindowSpec:
+    def orderBy(self, *cols: t.Union[ColumnOrName, t.Collection[ColumnOrName]]) -> WindowSpec:
         from sqlframe.base.column import Column
 
-        cols = flatten(cols) if isinstance(cols[0], (list, set, tuple)) else cols  # type: ignore
+        cols = flatten(cols) if isinstance(cols[0], t.Collection) else cols  # type: ignore
         expressions = [Column.ensure_col(x).expression for x in cols]  # type: ignore
         window_spec = self.copy()
         if window_spec.expression.args.get("order") is None:


### PR DESCRIPTION
The goal of this PR is to provide typing support, VSCode autocomplete and doc-reference when using the standalone API. While all of the methods on `BaseDataFrame` already have nice signatures, these are erased by the `@operation`-decorator. This decorator preserves a functions signature, just adding some extra code around it. That makes `t.Callable[P, T]` the simplest type, where `P = ParamSpec("P")` represents arbitrary arguments (including kwargs) and `T = t.TypeVar("T")` some return type.

I opted for the more specific signature of `t.Callable[Concatenate[DF, P], T]`, which allows for typechecking the implementation of `@operation` itself. This decomposes into:
- The first parameter of the function is some DataFrame `DF = t.TypeVar("DF", bound=BaseDataFrame)`
- The remaining parameters `P = ParamSpec("P")` are arbitrary (and just passed through)
- The return `T = t.TypeVar("T", bound=t.Union[BaseDataFrame, _BaseGroupedData])` is some subtype of `BaseDataFrame` or `_BaseGroupedData`

Unfortunately I was not able to make Pyright (used by VSCode autocomplete) to understand the analogous signature for `@group_operation`, so I simplified to `t.Callable[P, T]`.