### PR TITLE
feat: add support `sha1` for DuckDB

### DIFF
--- a/sqlframe/base/functions.py
+++ b/sqlframe/base/functions.py
@@ -1492,7 +1492,7 @@ def md5(col: ColumnOrName) -> Column:
     return Column.invoke_expression_over_column(col, expression.MD5)
 
 
-@meta(unsupported_engines=["duckdb", "postgres"])
+@meta(unsupported_engines=["postgres"])
 def sha1(col: ColumnOrName) -> Column:
     from sqlframe.base.function_alternatives import sha1_force_sha1_and_to_hex
 

--- a/sqlframe/duckdb/functions.pyi
+++ b/sqlframe/duckdb/functions.pyi
@@ -166,6 +166,7 @@ from sqlframe.base.functions import rpad as rpad
 from sqlframe.base.functions import rtrim as rtrim
 from sqlframe.base.functions import second as second
 from sqlframe.base.functions import sequence as sequence
+from sqlframe.base.functions import sha1 as sha1
 from sqlframe.base.functions import shiftLeft as shiftLeft
 from sqlframe.base.functions import shiftleft as shiftleft
 from sqlframe.base.functions import shiftRight as shiftRight


### PR DESCRIPTION
Adds support for [DuckDB's `sha1` function](https://duckdb.org/docs/stable/sql/functions/utility.html#sha1string); compatible to [PySparks's `sha1`](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.sha1.html)