### PR TITLE
feat: add support sha2 for DuckDB

### DIFF
--- a/sqlframe/base/function_alternatives.py
+++ b/sqlframe/base/function_alternatives.py
@@ -551,6 +551,17 @@ def sha1_force_sha1_and_to_hex(col: ColumnOrName) -> Column:
     )
 
 
+def sha2_sha265(col: ColumnOrName) -> Column:
+    col_func = get_func_from_session("col")
+
+    return Column(
+        expression.Anonymous(
+            this="SHA256",
+            expressions=[col_func(col).column_expression],
+        )
+    )
+
+
 def hash_from_farm_fingerprint(*cols: ColumnOrName) -> Column:
     if len(cols) > 1:
         raise ValueError("This dialect only supports a single column for calculating hash")

--- a/sqlframe/base/functions.py
+++ b/sqlframe/base/functions.py
@@ -1504,8 +1504,18 @@ def sha1(col: ColumnOrName) -> Column:
     return Column.invoke_expression_over_column(col, expression.SHA)
 
 
-@meta(unsupported_engines=["bigquery", "duckdb", "postgres"])
+@meta(unsupported_engines=["bigquery", "postgres"])
 def sha2(col: ColumnOrName, numBits: int) -> Column:
+    from sqlframe.base.function_alternatives import sha2_sha265
+
+    session = _get_session()
+
+    if session._is_duckdb:
+        if numBits in [256, 0]:
+            return sha2_sha265(col)
+        else:
+            raise ValueError("This dialect only supports SHA-265 (numBits=256 or numBits=0)")
+
     return Column.invoke_expression_over_column(col, expression.SHA2, length=lit(numBits))
 
 


### PR DESCRIPTION
Adds support for [DuckDB's `sha256` function](https://duckdb.org/docs/stable/sql/functions/utility.html#sha1string); compatible to [PySparks's `sha2` (numBits=256 or numBits=0)](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.sha2.html)