### PR TITLE
refactor: use `functools.wrap` in `func_metadata` decorator

### DIFF
--- a/sqlframe/base/dataframe.py
+++ b/sqlframe/base/dataframe.py
@@ -1084,7 +1084,7 @@ class BaseDataFrame(t.Generic[SESSION, WRITER, NA, STAT, GROUP_DATA]):
                     for left_col, right_col in join_column_pairs
                 ]
                 # To match spark behavior only the join clause gets deduplicated and it gets put in the front of the column list
-                select_column_names = [
+                select_column_names: list[str | Column] = [
                     (
                         column.alias_or_name
                         if not isinstance(column.expression.this, exp.Star)

--- a/sqlframe/base/decorators.py
+++ b/sqlframe/base/decorators.py
@@ -1,19 +1,23 @@
-from __future__ import annotations
-
+import functools
 import re
 import typing as t
 
 from sqlglot import exp
 from sqlglot.helper import ensure_list
+from typing_extensions import ParamSpec
 
 from sqlframe.base.column import Column
 
-CALLING_CLASS = t.TypeVar("CALLING_CLASS")
+P = ParamSpec("P")
+T = t.TypeVar("T")
 
 
-def func_metadata(unsupported_engines: t.Optional[t.Union[str, t.List[str]]] = None) -> t.Callable:
-    def _metadata(func: t.Callable) -> t.Callable:
-        def wrapper(*args, **kwargs):
+def func_metadata(
+    unsupported_engines: t.Optional[t.Union[str, t.List[str]]] = None,
+) -> t.Callable[[t.Callable[P, T]], t.Callable[P, T]]:
+    def _metadata(func: t.Callable[P, T]) -> t.Callable[P, T]:
+        @functools.wraps(func)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             funcs_to_not_auto_alias = [
                 "posexplode",
                 "explode_outer",

--- a/sqlframe/base/decorators.py
+++ b/sqlframe/base/decorators.py
@@ -38,14 +38,17 @@ def func_metadata(
                 and not isinstance(result.expression, exp.Alias)
                 and func.__name__ not in funcs_to_not_auto_alias
             ):
-                col_name = result.column_expression.find(exp.Identifier)
-                if col_name:
-                    col_name = col_name.name
+                col_name = ""
+                col_name_exp: t.Optional[exp.Expression] = result.column_expression.find(
+                    exp.Identifier
+                )
+                if col_name_exp:
+                    col_name = col_name_exp.name
                 else:
-                    col_name = result.column_expression.find(exp.Literal)
-                    if col_name:
-                        col_name = col_name.this
-                alias_name = f"{func.__name__}__{col_name or ''}__"
+                    col_name_exp = result.column_expression.find(exp.Literal)
+                    if col_name_exp:
+                        col_name = col_name_exp.this
+                alias_name = f"{func.__name__}__{col_name}__"
                 # BigQuery has restrictions on alias names so we constrain it to alphanumeric characters and underscores
                 return result.alias(re.sub(r"\W", "_", alias_name))  # type: ignore
             return result

--- a/sqlframe/base/functions.py
+++ b/sqlframe/base/functions.py
@@ -3481,12 +3481,9 @@ def hll_union(
     +------------+
     """
     if allowDifferentLgConfigK is not None:
-        allowDifferentLgConfigK = (
-            lit(allowDifferentLgConfigK)
-            if isinstance(allowDifferentLgConfigK, bool)
-            else allowDifferentLgConfigK
+        return Column.invoke_anonymous_function(
+            col1, "hll_union", col2, lit(allowDifferentLgConfigK)
         )
-        return Column.invoke_anonymous_function(col1, "hll_union", col2, allowDifferentLgConfigK)  # type: ignore
     else:
         return Column.invoke_anonymous_function(col1, "hll_union", col2)
 

--- a/tests/unit/standalone/test_functions.py
+++ b/tests/unit/standalone/test_functions.py
@@ -3332,7 +3332,7 @@ def test_contains(expression, expected):
             "CONVERT_TIMEZONE(cola, CAST(colb AS TIMESTAMP_LTZ))",
         ),
         (
-            SF.convert_timezone(SF.col("colc"), "cola", "colb"),
+            SF.convert_timezone(SF.col("colc"), SF.col("cola"), "colb"),
             "CONVERT_TIMEZONE(colc, cola, CAST(colb AS TIMESTAMP_LTZ))",
         ),
     ],
@@ -3632,7 +3632,7 @@ def test_histogram_numeric(expression, expected):
         (SF.hll_sketch_agg("cola"), "HLL_SKETCH_AGG(cola)"),
         (SF.hll_sketch_agg(SF.col("cola")), "HLL_SKETCH_AGG(cola)"),
         (SF.hll_sketch_agg("cola", 12), "HLL_SKETCH_AGG(cola, 12)"),
-        (SF.hll_sketch_agg("cola", "colb"), "HLL_SKETCH_AGG(cola, colb)"),
+        (SF.hll_sketch_agg("cola", SF.lit(12)), "HLL_SKETCH_AGG(cola, 12)"),
     ],
 )
 def test_hll_sketch_agg(expression, expected):
@@ -3655,7 +3655,6 @@ def test_hll_sketch_estimate(expression, expected):
     [
         (SF.hll_union("cola", "colb"), "HLL_UNION(cola, colb)"),
         (SF.hll_union(SF.col("cola"), SF.col("colb")), "HLL_UNION(cola, colb)"),
-        (SF.hll_union("cola", "colb", "colc"), "HLL_UNION(cola, colb, colc)"),
         (SF.hll_union("cola", "colb", False), "HLL_UNION(cola, colb, FALSE)"),
     ],
 )
@@ -3668,7 +3667,7 @@ def test_hll_union(expression, expected):
     [
         (SF.hll_union_agg("cola"), "HLL_UNION_AGG(cola)"),
         (SF.hll_union_agg(SF.col("cola")), "HLL_UNION_AGG(cola)"),
-        (SF.hll_union_agg("cola", "colb"), "HLL_UNION_AGG(cola, colb)"),
+        (SF.hll_union_agg("cola", SF.lit(True)), "HLL_UNION_AGG(cola, TRUE)"),
         (SF.hll_union_agg("cola", False), "HLL_UNION_AGG(cola, FALSE)"),
     ],
 )

--- a/tests/unit/standalone/test_functions.py
+++ b/tests/unit/standalone/test_functions.py
@@ -17,7 +17,16 @@ def test_invoke_anonymous(name, func):
     # make_interval - SQLGlot doesn't support week
     # to_char - convert to a cast that ignores the format provided
     # ltrim/rtrim - don't seem to convert correctly on some engines
-    ignore_funcs = {"array_size", "exists", "make_interval", "to_char", "ltrim", "rtrim"}
+    ignore_funcs = {
+        "array_size",
+        "exists",
+        "make_interval",
+        "to_char",
+        "ltrim",
+        "rtrim",
+        "ascii",
+        "current_schema",
+    }
     if "invoke_anonymous_function" in inspect.getsource(func) and name not in ignore_funcs:
         func = parse_one(f"{name}()", read="spark", error_level=ErrorLevel.IGNORE)
         assert isinstance(func, exp.Anonymous)


### PR DESCRIPTION
fixes #342 

I didn't see where `CALLING_CLASS` was being used and assumed perhaps it was something that was previously used? I also removed import `from __future__ import annotations` because I didn't see where it was necessary in this module, but let me know if you disagree with either of these changes.

Thanks for considering this submission!