### PR TITLE
fix: `df.head()` and `df.first()` on empty `DataFrame`

### DIFF
--- a/sqlframe/base/dataframe.py
+++ b/sqlframe/base/dataframe.py
@@ -1850,11 +1850,10 @@ class BaseDataFrame(t.Generic[SESSION, WRITER, NA, STAT, GROUP_DATA]):
     def head(self, n: int) -> t.List[Row]: ...
 
     def head(self, n: t.Optional[int] = None) -> t.Union[t.Optional[Row], t.List[Row]]:
-        n = n or 1
-        df = self.limit(n)
+        df = self.limit(n or 1)
         collected = df.collect()
-        if n == 1:
-            return None if collected == [] else collected[0]
+        if n is None:
+            return seq_get(collected, 0)
         return collected
 
     def first(self) -> t.Optional[Row]:

--- a/sqlframe/base/dataframe.py
+++ b/sqlframe/base/dataframe.py
@@ -1852,9 +1852,10 @@ class BaseDataFrame(t.Generic[SESSION, WRITER, NA, STAT, GROUP_DATA]):
     def head(self, n: t.Optional[int] = None) -> t.Union[t.Optional[Row], t.List[Row]]:
         n = n or 1
         df = self.limit(n)
+        collected = df.collect()
         if n == 1:
-            return df.collect()[0]
-        return df.collect()
+            return None if collected == [] else collected[0]
+        return collected
 
     def first(self) -> t.Optional[Row]:
         return self.head()

--- a/tests/integration/engines/test_engine_dataframe.py
+++ b/tests/integration/engines/test_engine_dataframe.py
@@ -189,3 +189,28 @@ def test_show_from_create_with_space_with_schema(get_session: t.Callable[[], _Ba
     df.printSchema()
     captured = capsys.readouterr()
     assert "|-- an tan:" in captured.out.strip()
+
+
+def test_head(get_session, get_func):
+    session = get_session()
+    lit = get_func("lit", session)
+    df_non_empty = session.createDataFrame(
+        data=[(2, "Alice"), (5, "Bob"), (8, "Charly")],
+        schema=["age", "name"],
+    )
+    df_empty = df_non_empty.filter(lit(False))
+
+    # head() on DataFrame containing data: single row
+    assert df_non_empty.head() == Row(**{"age": 2, "name": "Alice"})
+
+    # head() on empty DataFrame: None
+    assert df_empty.head() is None
+
+    # head(n) on DataFrame containing data: list of rows
+    assert df_non_empty.head(2) == [
+        Row(**{"age": 2, "name": "Alice"}),
+        Row(**{"age": 5, "name": "Bob"}),
+    ]
+
+    # head(n) on empty DataFrame : empty list
+    assert df_empty.head(2) == []

--- a/tests/integration/test_int_dataframe.py
+++ b/tests/integration/test_int_dataframe.py
@@ -2672,3 +2672,16 @@ def test_alias_group_by_column(
     dfs = dfs.groupBy(SF.col("name").alias("Firstname")).count()
 
     compare_frames(df, dfs, compare_schema=False, sort=True)
+
+
+def test_head(
+    pyspark_employee: PySparkDataFrame,
+    get_df: t.Callable[[str], BaseDataFrame],
+):
+    row = pyspark_employee.head()
+    rows = get_df("employee").head()
+    assert row == rows
+
+    row = pyspark_employee.filter(F.lit(False)).head()
+    rows = get_df("employee").filter(SF.lit(False)).head()
+    assert row == rows

--- a/tests/integration/test_int_dataframe.py
+++ b/tests/integration/test_int_dataframe.py
@@ -2672,20 +2672,3 @@ def test_alias_group_by_column(
     dfs = dfs.groupBy(SF.col("name").alias("Firstname")).count()
 
     compare_frames(df, dfs, compare_schema=False, sort=True)
-
-
-def test_head(
-    pyspark_employee: PySparkDataFrame,
-    get_df: t.Callable[[str], BaseDataFrame],
-):
-    employee = get_df("employee")
-
-    # head() on DataFrame containing data
-    row = pyspark_employee.head()
-    row_sf = employee.head()
-    assert row == row_sf
-
-    # head() on empty DataFrame
-    row = pyspark_employee.filter(F.lit(False)).head()
-    row_sf = employee.filter(SF.lit(False)).head()
-    assert row == row_sf

--- a/tests/integration/test_int_dataframe.py
+++ b/tests/integration/test_int_dataframe.py
@@ -2678,10 +2678,14 @@ def test_head(
     pyspark_employee: PySparkDataFrame,
     get_df: t.Callable[[str], BaseDataFrame],
 ):
-    row = pyspark_employee.head()
-    rows = get_df("employee").head()
-    assert row == rows
+    employee = get_df("employee")
 
+    # head() on DataFrame containing data
+    row = pyspark_employee.head()
+    row_sf = employee.head()
+    assert row == row_sf
+
+    # head() on empty DataFrame
     row = pyspark_employee.filter(F.lit(False)).head()
-    rows = get_df("employee").filter(SF.lit(False)).head()
-    assert row == rows
+    row_sf = employee.filter(SF.lit(False)).head()
+    assert row == row_sf


### PR DESCRIPTION
`DataFrame.head()` and `DataFrame.first()` used to raise `IndexError: list index out of range`. PySpark returns `None`.