### PR TITLE
feat: add `DataFrame.isEmpty()`

### DIFF
--- a/sqlframe/base/dataframe.py
+++ b/sqlframe/base/dataframe.py
@@ -1938,7 +1938,7 @@ class BaseDataFrame(t.Generic[SESSION, WRITER, NA, STAT, GROUP_DATA]):
     def isEmpty(self) -> bool:
         from sqlframe.base import functions as F
 
-        return True if self.select(F.lit(True)).head(1) == [] else False
+        return not bool(self.select(F.lit(True)).head())
 
     """
     Stat Functions

--- a/sqlframe/base/dataframe.py
+++ b/sqlframe/base/dataframe.py
@@ -1935,6 +1935,11 @@ class BaseDataFrame(t.Generic[SESSION, WRITER, NA, STAT, GROUP_DATA]):
     def createGlobalTempView(self, name: str) -> None:
         raise NotImplementedError("Global temp views are not yet supported")
 
+    def isEmpty(self) -> bool:
+        from sqlframe.base import functions as F
+
+        return True if self.select(F.lit(True)).head(1) == [] else False
+
     """
     Stat Functions
     """

--- a/tests/integration/engines/test_engine_dataframe.py
+++ b/tests/integration/engines/test_engine_dataframe.py
@@ -189,3 +189,12 @@ def test_show_from_create_with_space_with_schema(get_session: t.Callable[[], _Ba
     df.printSchema()
     captured = capsys.readouterr()
     assert "|-- an tan:" in captured.out.strip()
+
+
+def test_is_empty(get_session):
+    session = get_session()
+    df_non_empty = session.createDataFrame([(1, 4), (2, 5), (3, 6)], schema=["foo", "BAR"])
+    df_empty = session.createDataFrame([], schema=["foo", "BAR"])
+
+    assert not df_non_empty.isEmpty()
+    assert df_empty.isEmpty()

--- a/tests/integration/test_int_dataframe.py
+++ b/tests/integration/test_int_dataframe.py
@@ -2672,3 +2672,19 @@ def test_alias_group_by_column(
     dfs = dfs.groupBy(SF.col("name").alias("Firstname")).count()
 
     compare_frames(df, dfs, compare_schema=False, sort=True)
+
+
+def test_is_empty(
+    pyspark_employee: PySparkDataFrame,
+    get_df: t.Callable[[str], BaseDataFrame],
+):
+    session_pyspark = pyspark_employee.sparkSession
+    session_sf = get_df("employee").sparkSession
+
+    df = session_pyspark.createDataFrame([], "name STRING")
+    df_sf = session_sf.createDataFrame([], "name STRING")
+    assert df.isEmpty() == df_sf.isEmpty()
+
+    df = session_pyspark.createDataFrame([(2, "Alice")], schema=["age", "name"])
+    df_sf = session_sf.createDataFrame([(2, "Alice")], schema=["age", "name"])
+    assert df.isEmpty() == df_sf.isEmpty()

--- a/tests/integration/test_int_dataframe.py
+++ b/tests/integration/test_int_dataframe.py
@@ -2672,19 +2672,3 @@ def test_alias_group_by_column(
     dfs = dfs.groupBy(SF.col("name").alias("Firstname")).count()
 
     compare_frames(df, dfs, compare_schema=False, sort=True)
-
-
-def test_is_empty(
-    pyspark_employee: PySparkDataFrame,
-    get_df: t.Callable[[str], BaseDataFrame],
-):
-    session_pyspark = pyspark_employee.sparkSession
-    session_sf = get_df("employee").sparkSession
-
-    df = session_pyspark.createDataFrame([], "name STRING")
-    df_sf = session_sf.createDataFrame([], "name STRING")
-    assert df.isEmpty() == df_sf.isEmpty()
-
-    df = session_pyspark.createDataFrame([(2, "Alice")], schema=["age", "name"])
-    df_sf = session_sf.createDataFrame([(2, "Alice")], schema=["age", "name"])
-    assert df.isEmpty() == df_sf.isEmpty()


### PR DESCRIPTION
Support for [pyspark.sql.DataFrame.isEmpty()](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.isEmpty.html)
Requires PR https://github.com/eakmanrq/sqlframe/pull/362 (fix for `DataFrame.head()`).