### PR TITLE
handle InvalidInputException from duckdb when numpy is not installed

### DIFF
--- a/sqlframe/duckdb/session.py
+++ b/sqlframe/duckdb/session.py
@@ -41,13 +41,14 @@ class DuckDBSession(
 
     def __init__(self, conn: t.Optional[DuckDBPyConnection] = None, *args, **kwargs):
         import duckdb
+        from duckdb import InvalidInputException
         from duckdb.typing import VARCHAR
 
         if not hasattr(self, "_conn"):
             conn = conn or duckdb.connect()
             try:
                 conn.create_function("SOUNDEX", lambda x: soundex(x), return_type=VARCHAR)
-            except ImportError:
+            except (ImportError, InvalidInputException):
                 pass
 
             super().__init__(conn, *args, **kwargs)


### PR DESCRIPTION
fixes #380 

Not sure when `InvalidInputException` got introduced in duckdb though. Tested with ddb 1.2.0 and 1.2.2.
How many old duckdb versions to you support?