### PR TITLE
feat: have try_divide support all engines

### DIFF
--- a/docs/bigquery.md
+++ b/docs/bigquery.md
@@ -516,6 +516,7 @@ See something that you would like to see supported? [Open an issue](https://gith
 * [trim](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.trim.html)
 * [trunc](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.trunc.html)
     * Shorthand expressions not supported. Ex: Use `month` instead of `mon`
+* [try_divide](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.try_divide.html)
 * [try_to_timestamp](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.try_to_timestamp.html)
 * [typeof](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.typeof.html)
 * [ucase](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.ucase.html)

--- a/docs/duckdb.md
+++ b/docs/duckdb.md
@@ -478,6 +478,7 @@ See something that you would like to see supported? [Open an issue](https://gith
 * [translate](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.translate.html)
 * [trim](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.trim.html)
 * [trunc](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.trunc.html)
+* [try_divide](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.try_divide.html)
 * [try_element_at](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.try_element_at.html)
 * [try_to_timestamp](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.try_to_timestamp.html)
 * [typeof](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.typeof.html)

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -464,6 +464,7 @@ See something that you would like to see supported? [Open an issue](https://gith
 * [translate](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.translate.html)
 * [trim](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.trim.html)
 * [trunc](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.trunc.html)
+* [try_divide](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.try_divide.html)
 * [try_element_at](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.try_element_at.html)
   * Negative index returns null and cannot lookup elements in maps
 * [try_to_timestamp](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.try_to_timestamp.html)

--- a/docs/snowflake.md
+++ b/docs/snowflake.md
@@ -516,6 +516,7 @@ See something that you would like to see supported? [Open an issue](https://gith
 * [translate](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.translate.html)
 * [trim](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.trim.html)
 * [trunc](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.trunc.html)
+* [try_divide](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.try_divide.html)
 * [try_to_timestamp](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.try_to_timestamp.html)
 * [typeof](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.typeof.html)
 * [ucase](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.ucase.html)

--- a/sqlframe/base/functions.py
+++ b/sqlframe/base/functions.py
@@ -2801,9 +2801,11 @@ def try_avg(col: ColumnOrName) -> Column:
     return Column.invoke_anonymous_function(col, "TRY_AVG")
 
 
-@meta(unsupported_engines="*")
+@meta()
 def try_divide(left: ColumnOrName, right: ColumnOrName) -> Column:
-    return Column.invoke_anonymous_function(left, "TRY_DIVIDE", right)
+    return Column.invoke_expression_over_column(
+        left, expression.SafeDivide, expression=Column.ensure_col(right).column_expression
+    )
 
 
 @meta(unsupported_engines="*")

--- a/tests/integration/engines/test_int_functions.py
+++ b/tests/integration/engines/test_int_functions.py
@@ -3112,10 +3112,11 @@ def test_try_divide(get_session_and_func, get_func):
     session, try_divide = get_session_and_func("try_divide")
     make_interval = get_func("make_interval", session)
     lit = get_func("lit", session)
-    df = session.createDataFrame([(6000, 15), (1990, 2)], ["a", "b"])
+    df = session.createDataFrame([(6000, 15), (1990, 2), (100, 0)], ["a", "b"])
     assert df.select(try_divide(df.a, df.b).alias("r")).collect() == [
         Row(r=400.0),
         Row(r=995.0),
+        Row(r=None),
     ]
     df = session.createDataFrame([(1, 2)], ["year", "month"])
     assert (

--- a/tests/unit/standalone/test_functions.py
+++ b/tests/unit/standalone/test_functions.py
@@ -3012,8 +3012,11 @@ def test_try_avg(expression, expected):
 @pytest.mark.parametrize(
     "expression, expected",
     [
-        (SF.try_divide("cola", "colb"), "TRY_DIVIDE(cola, colb)"),
-        (SF.try_divide(SF.col("cola"), SF.col("colb")), "TRY_DIVIDE(cola, colb)"),
+        (SF.try_divide("cola", "colb"), "IF(colb <> 0, cola / colb, NULL)"),
+        (
+            SF.try_divide(SF.col("cola"), SF.col("colb")),
+            "IF(colb <> 0, cola / colb, NULL)",
+        ),
     ],
 )
 def test_try_divide(expression, expected):


### PR DESCRIPTION
Resolves: https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.try_divide.html