### PR TITLE
add failing test case for ENDS_WITH not working in duckdb

### DIFF
--- a/tests/integration/engines/duck/test_duckdb_functions.py
+++ b/tests/integration/engines/duck/test_duckdb_functions.py
@@ -1,0 +1,22 @@
+import duckdb
+
+from sqlframe.duckdb import DuckDBSession
+from sqlframe.duckdb import functions as F
+
+
+def test_ends_with():
+    con = duckdb.connect(database=":memory:")
+    session: DuckDBSession = DuckDBSession(conn=con)
+
+    df = session.createDataFrame([["abc"]], schema=["col1"])
+
+    df = df.filter((F.col("col1").endswith("c")))
+
+    sql = df.sql(dialect="duckdb")
+    print(sql)
+
+    assert "ENDS_WITH" in sql
+    """
+    >       assert "ENDS_WITH" in sql
+E       assert 'ENDS_WITH' in 'SELECT\n  CAST("a1"."col1" AS TEXT) AS "col1"\nFROM (VALUES\n  (\'abc\')) AS "a1"("col1")\nWHERE\n  ENDSWITH(CAST("a1"."col1" AS TEXT), \'c\')'
+    """


### PR DESCRIPTION
This change broke the ENDS_WITH support for me with duckdb as output dialect. 

https://github.com/eakmanrq/sqlframe/pull/424/files

I have added a test case for now to reproduce the issue.

https://duckdb.org/docs/stable/sql/functions/text.html#ends_withstring-search_string