### PR TITLE
feat: add datetime timedelta literal support

### DIFF
--- a/sqlframe/base/column.py
+++ b/sqlframe/base/column.py
@@ -222,6 +222,12 @@ class Column:
             else:
                 value = value.astimezone(datetime.timezone.utc).isoformat(sep=" ")
                 return cls(exp.cast(exp.Literal.string(value), exp.DataType.Type.TIMESTAMPTZ))
+        elif isinstance(value, datetime.timedelta):
+            return cls(
+                exp.Interval(
+                    this=exp.Literal.string(int(value.total_seconds())), unit=exp.Var(this="SECOND")
+                )
+            )
         return cls(exp.convert(value))
 
     @classmethod

--- a/sqlframe/base/session.py
+++ b/sqlframe/base/session.py
@@ -12,6 +12,7 @@ from collections import defaultdict
 from functools import cached_property
 
 import sqlglot
+from dateutil.relativedelta import relativedelta
 from sqlglot import Dialect, exp
 from sqlglot.dialects.dialect import DialectType, NormalizationStrategy
 from sqlglot.expressions import parse_identifier
@@ -613,6 +614,11 @@ class _BaseSession(t.Generic[CATALOG, READER, WRITER, DF, TABLE, CONN, UDF_REGIS
             return [cls._to_value(x) for x in value]
         elif isinstance(value, datetime.datetime):
             return value.replace(tzinfo=None)
+        elif isinstance(value, relativedelta):
+            return datetime.timedelta(
+                days=value.days, hours=value.hours, minutes=value.minutes, seconds=value.seconds
+            )
+
         return value
 
     @classmethod

--- a/tests/integration/engines/test_int_functions.py
+++ b/tests/integration/engines/test_int_functions.py
@@ -121,6 +121,7 @@ def get_types() -> t.Callable:
         ),
         ({"cola": 1}, {"cola": 1}),
         (Row(**{"cola": 1, "colb": "test"}), Row(**{"cola": 1, "colb": "test"})),
+        (datetime.timedelta(1), datetime.timedelta(1)),
     ],
 )
 def test_lit(get_session_and_func, arg, expected):
@@ -141,6 +142,11 @@ def test_lit(get_session_and_func, arg, expected):
     if isinstance(session, SnowflakeSession):
         if isinstance(arg, Row):
             pytest.skip("Snowflake doesn't support literal row types")
+        if isinstance(arg, datetime.timedelta):
+            pytest.skip("Snowflake doesn't support literal timedelta types")
+    if isinstance(session, DatabricksSession):
+        if isinstance(arg, datetime.timedelta):
+            pytest.skip("Databricks doesn't support literal timedelta types")
     if isinstance(session, DuckDBSession):
         if isinstance(arg, dict):
             expected = Row(**expected)


### PR DESCRIPTION
Initial support for https://github.com/eakmanrq/sqlframe/issues/454

The displayed value when doing `show` looks different from pyspark, but the test shows that when processing a literal of the time delta we get the same value back (except for engines that aren't supported). 