### PR TITLE
fix: handle timestamp type unix timestamp functions

### DIFF
--- a/sqlframe/base/functions.py
+++ b/sqlframe/base/functions.py
@@ -1450,6 +1450,9 @@ def unix_timestamp(
 
     session = _get_session()
 
+    if session._is_duckdb or session._is_postgres or session._is_snowflake or session._is_bigquery:
+        timestamp = Column.ensure_col(timestamp).cast("string")
+
     if session._is_bigquery:
         return unix_timestamp_bgutil(timestamp, format)
 
@@ -6342,6 +6345,7 @@ def to_unix_timestamp(
 
     if session._is_duckdb:
         format = format or _BaseSession().default_time_format
+        timestamp = Column.ensure_col(timestamp).cast("string")
 
     if format is not None:
         return Column.invoke_expression_over_column(

--- a/tests/integration/engines/test_int_functions.py
+++ b/tests/integration/engines/test_int_functions.py
@@ -1502,10 +1502,14 @@ def test_from_unixtime(get_session_and_func):
     assert df.select(from_unixtime("unix_time").alias("ts")).first()[0] == expected
 
 
-def test_unix_timestamp(get_session_and_func):
+def test_unix_timestamp(get_session_and_func, get_func):
     session, unix_timestamp = get_session_and_func("unix_timestamp")
     df = session.createDataFrame([("2015-04-08",)], ["dt"])
     result = df.select(unix_timestamp("dt", "yyyy-MM-dd").alias("unix_time")).first()[0]
+    assert result == 1428451200
+    ts_type = "TIMESTAMP" if isinstance(session, PySparkSession) else "TIMESTAMPNTZ"
+    df = session.createDataFrame([(datetime.datetime(2015, 4, 8),)], schema=f"ts {ts_type}")
+    result = df.select(unix_timestamp("ts").alias("unix_time")).first()[0]
     assert result == 1428451200
 
 
@@ -5003,6 +5007,12 @@ def test_to_unix_timestamp(get_session_and_func, get_func):
     else:
         df = session.createDataFrame([("2016-04-08",)], ["e"])
         assert df.select(to_unix_timestamp(df.e).alias("r")).collect() == [Row(r=None)]
+    ts_type = "TIMESTAMP" if isinstance(session, PySparkSession) else "TIMESTAMPNTZ"
+    df = session.createDataFrame([(datetime.datetime(2015, 4, 8),)], schema=f"ts {ts_type}")
+    result = df.select(
+        to_unix_timestamp("ts", lit("yyyy-MM-dd HH:mm:ss")).alias("unix_time")
+    ).first()[0]
+    assert result == 1428451200
 
 
 def test_to_varchar(get_session_and_func, get_func):


### PR DESCRIPTION
Resolves: https://github.com/eakmanrq/sqlframe/issues/480

Addresses one of the issues in https://github.com/eakmanrq/sqlframe/issues/474