### PR TITLE
fix NameError: name '_BaseSession' is not defined. Did you mean: '_ge…

### DIFF
--- a/sqlframe/base/functions.py
+++ b/sqlframe/base/functions.py
@@ -6344,7 +6344,7 @@ def to_unix_timestamp(
     session = _get_session()
 
     if session._is_duckdb:
-        format = format or _BaseSession().default_time_format
+        format = format or session.default_time_format
         timestamp = Column.ensure_col(timestamp).cast("string")
 
     if format is not None:


### PR DESCRIPTION
…t_session'?

 File "/foundry/user_code/myproject/datasets/ontology_backing_datasets/harbor_table_logs.py", line 195, in compute
    F.to_unix_timestamp(F.col("timestamp")),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/foundry/python_environment/lib/python3.12/site-packages/sqlframe/base/decorators.py", line 34, in wrapper
    result = func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/foundry/python_environment/lib/python3.12/site-packages/sqlframe/base/functions.py", line 6347, in to_unix_timestamp
    format = format or _BaseSession().default_time_format
                       ^^^^^^^^^^^^
NameError: name '_BaseSession' is not defined. Did you mean: '_get_session'?