### PR TITLE
fix: allow dataframe aliases to be provided to groupBy columns

### DIFF
--- a/tests/integration/test_int_dataframe.py
+++ b/tests/integration/test_int_dataframe.py
@@ -2691,6 +2691,30 @@ def test_alias_group_by_column(
     compare_frames(df, dfs, compare_schema=False, sort=True)
 
 
+# https://github.com/eakmanrq/sqlframe/issues/502
+def test_group_by_alias(
+    pyspark_employee: PySparkDataFrame,
+    get_df: t.Callable[[str], BaseDataFrame],
+    compare_frames: t.Callable,
+):
+    df = pyspark_employee.sparkSession.createDataFrame(
+        [(2, "Alice"), (2, "Bob"), (2, "Bob"), (5, "Bob")], schema=["age", "name"]
+    )
+    df = df.select(F.col("name"), F.col("age")).groupBy(F.col("name")).count()
+
+    dfs = get_df("employee").sparkSession.createDataFrame(
+        [(2, "Alice"), (2, "Bob"), (2, "Bob"), (5, "Bob")], schema=["age", "name"]
+    )
+    dfs = (
+        dfs.alias("df")
+        .select(SF.col("df.name"), SF.col("df.age"))
+        .groupBy(SF.col("df.name"))
+        .count()
+    )
+
+    compare_frames(df, dfs, compare_schema=False, sort=True)
+
+
 # https://github.com/eakmanrq/sqlframe/issues/493
 def test_alias_multiple_joins(
     pyspark_employee: PySparkDataFrame,

--- a/tests/unit/standalone/test_dataframe.py
+++ b/tests/unit/standalone/test_dataframe.py
@@ -188,3 +188,14 @@ def test_aliased_dictionary_agg(standalone_employee: StandaloneDataFrame):
         standalone_employee.groupBy("fname").agg({"age": "avg", "lname": "count"}).sql(pretty=False)
         == "SELECT CAST(`a1`.`fname` AS STRING) AS `fname`, AVG(`a1`.`age`) AS `avg(age)`, COUNT(CAST(`a1`.`lname` AS STRING)) AS `count(lname)` FROM VALUES (1, 'Jack', 'Shephard', 37, 1), (2, 'John', 'Locke', 65, 1), (3, 'Kate', 'Austen', 37, 2), (4, 'Claire', 'Littleton', 27, 2), (5, 'Hugo', 'Reyes', 29, 100) AS `a1`(`employee_id`, `fname`, `lname`, `age`, `store_id`) GROUP BY CAST(`a1`.`fname` AS STRING)"
     )
+
+
+def test_aliased_group_by(standalone_employee: StandaloneDataFrame):
+    assert (
+        standalone_employee.alias("employee")
+        .select(F.col("employee.fname"))
+        .groupBy(F.col("employee.fname"))
+        .count()
+        .sql(pretty=False)
+        == "SELECT CAST(`a1`.`fname` AS STRING) AS `fname`, COUNT(*) AS `count` FROM VALUES (1, 'Jack', 'Shephard', 37, 1), (2, 'John', 'Locke', 65, 1), (3, 'Kate', 'Austen', 37, 2), (4, 'Claire', 'Littleton', 27, 2), (5, 'Hugo', 'Reyes', 29, 100) AS `a1`(`employee_id`, `fname`, `lname`, `age`, `store_id`) GROUP BY CAST(`a1`.`fname` AS STRING)"
+    )


### PR DESCRIPTION
Resolves: #502

Enables:

```python
from sqlframe import standalone
from sqlframe.base import functions as f

spark = standalone.StandaloneSession()

df = spark.createDataFrame([{"foo": 0, "bar": "a"}, {"foo": 1, "bar": "b"}]).alias("df")
print(df.alias("df").select(f.col("df.foo"), f.col("df.bar")).groupBy(f.col("df.foo")).count().sql())
```

```sql
SELECT
  CAST(`a1`.`foo` AS BIGINT) AS `foo`,
  COUNT(*) AS `count`
FROM VALUES
  (0, 'a'),
  (1, 'b') AS `a1`(`foo`, `bar`)
GROUP BY
  CAST(`a1`.`foo` AS BIGINT)
```