### PR TITLE
fix(duckdb): Import `VARCHAR` from `duckdb.sqltypes`

### DIFF
--- a/sqlframe/duckdb/session.py
+++ b/sqlframe/duckdb/session.py
@@ -7,10 +7,7 @@ from sqlframe.base.session import _BaseSession
 from sqlframe.base.util import soundex
 from sqlframe.duckdb.catalog import DuckDBCatalog
 from sqlframe.duckdb.dataframe import DuckDBDataFrame
-from sqlframe.duckdb.readwriter import (
-    DuckDBDataFrameReader,
-    DuckDBDataFrameWriter,
-)
+from sqlframe.duckdb.readwriter import DuckDBDataFrameReader, DuckDBDataFrameWriter
 from sqlframe.duckdb.table import DuckDBTable
 from sqlframe.duckdb.udf import DuckDBUDFRegistration
 
@@ -42,6 +39,7 @@ class DuckDBSession(
     def __init__(self, conn: t.Optional[DuckDBPyConnection] = None, *args, **kwargs):
         import duckdb
         from duckdb import InvalidInputException
+
         try:  # Available from duckdb 1.4.1
             from duckdb.sqltypes import VARCHAR
         except ImportError:


### PR DESCRIPTION
# Description

Closes #531 by first trying to import from `duckdb.sqltypes`. If that's not found it fallbacks to `duckdb.typing`