### PR TITLE
fix: least/greatest ignores nulls

### DIFF
--- a/docs/bigquery.md
+++ b/docs/bigquery.md
@@ -415,6 +415,7 @@ See something that you would like to see supported? [Open an issue](https://gith
 * [get_json_object](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.get_json_object.html)
     * Values are returned quoted while Spark strips the quotes
 * [greatest](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.greatest.html)
+    * A null value returns a null result
 * [grouping](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.grouping.html)
 * [hash](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.hash.html)
     * Use a different hash algorithm than Spark
@@ -433,6 +434,7 @@ See something that you would like to see supported? [Open an issue](https://gith
 * [lcase](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.lcase.html)
 * [lead](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.lead.html)
 * [least](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.least.html)
+  * A null value returns a null result
 * [left](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.left.html)
 * [length](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.length.html)
 * [lit](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.lit.html)

--- a/sqlframe/base/functions.py
+++ b/sqlframe/base/functions.py
@@ -70,18 +70,40 @@ def lit(value: t.Optional[t.Any] = None) -> Column:
 
 @meta()
 def greatest(*cols: ColumnOrName) -> Column:
-    if len(cols) > 1:
-        return Column.invoke_expression_over_column(
-            cols[0], expression.Greatest, expressions=cols[1:]
+    columns = [x.column_expression for x in Column.ensure_cols(list(cols))]
+    if len(columns) > 1:
+        return Column(
+            expression.Greatest(
+                this=columns[0],
+                expressions=columns[1:],
+                ignore_nulls=True,
+            )
         )
-    return Column.invoke_expression_over_column(cols[0], expression.Greatest)
+    return Column(
+        expression.Greatest(
+            this=columns[0],
+            ignore_nulls=True,
+        )
+    )
 
 
 @meta()
 def least(*cols: ColumnOrName) -> Column:
-    if len(cols) > 1:
-        return Column.invoke_expression_over_column(cols[0], expression.Least, expressions=cols[1:])
-    return Column.invoke_expression_over_column(cols[0], expression.Least)
+    columns = [x.column_expression for x in Column.ensure_cols(list(cols))]
+    if len(columns) > 1:
+        return Column(
+            expression.Least(
+                this=columns[0],
+                expressions=columns[1:],
+                ignore_nulls=True,
+            )
+        )
+    return Column(
+        expression.Least(
+            this=columns[0],
+            ignore_nulls=True,
+        )
+    )
 
 
 @meta()

--- a/tests/integration/engines/test_int_functions.py
+++ b/tests/integration/engines/test_int_functions.py
@@ -1114,6 +1114,13 @@ def test_greatest(get_session_and_func):
     assert df.select(greatest(df.a, df.b, df.c).alias("greatest")).collect() == [
         Row(greatest=4),
     ]
+    if not isinstance(session, (PySparkSession, BigQuerySession)):
+        df = session.createDataFrame([(1, 4, 3, None)], ["a", "b", "c", "d"])
+        assert df.select(
+            greatest(df.a, df.b, df.c, df.d.cast("bigint")).alias("greatest")
+        ).collect() == [
+            Row(greatest=4),
+        ]
 
 
 def test_least(get_session_and_func):
@@ -1122,6 +1129,11 @@ def test_least(get_session_and_func):
     assert df.select(least(df.a, df.b, df.c).alias("least")).collect() == [
         Row(least=1),
     ]
+    if not isinstance(session, (PySparkSession, BigQuerySession)):
+        df = session.createDataFrame([(1, 4, 3, None)], ["a", "b", "c", "d"])
+        assert df.select(least(df.a, df.b, df.c, df.d.cast("bigint")).alias("least")).collect() == [
+            Row(least=1),
+        ]
 
 
 def test_when(get_session_and_func):


### PR DESCRIPTION
Resolves: https://github.com/eakmanrq/sqlframe/issues/577

Open question about why BigQuery doesn't seem to respect the ignore_nulls property. I'm leaning towards it being a bug in SQLGlot but decided it wasn't worth the time to debug further so just documented instead. 