### PR TITLE
fix: to_date double PARSE_TIMESTAMP for BigQuery

### DIFF
--- a/sqlframe/base/functions.py
+++ b/sqlframe/base/functions.py
@@ -1367,6 +1367,7 @@ def to_date(col: ColumnOrName, format: t.Optional[str] = None) -> Column:
     if session._is_bigquery:
         to_timestamp_func = get_func_from_session("to_timestamp")
         col = to_timestamp_func(col, format)
+        return Column.invoke_expression_over_column(col, expression.TsOrDsToDate)
 
     if session._is_snowflake:
         format = format or session.default_time_format

--- a/tests/integration/engines/test_int_functions.py
+++ b/tests/integration/engines/test_int_functions.py
@@ -1461,6 +1461,10 @@ def test_to_date(get_session_and_func):
         assert result == datetime.date(1997, 2, 28)
     else:
         assert result == datetime.date(1997, 2, 28)
+    # Compact date format exposes double PARSE_TIMESTAMP bug on BigQuery
+    df2 = session.createDataFrame([("19970228",)], ["t"])
+    result2 = df2.select(to_date(df2.t, "yyyyMMdd").alias("date")).first()[0]
+    assert result2 == datetime.date(1997, 2, 28)
 
 
 def test_to_timestamp(get_session_and_func):


### PR DESCRIPTION
## Summary

- `to_date(col, format)` on BigQuery was generating a double `PARSE_TIMESTAMP` call, e.g. `CAST(PARSE_TIMESTAMP('%Y%m%d', PARSE_TIMESTAMP('%Y%m%d', col)) AS DATE)`, which causes a BigQuery runtime error since the outer call receives a `TIMESTAMP` instead of a `STRING`
- Root cause: after converting `col` via `to_timestamp()`, the code fell through to the `if format is not None` block and wrapped it in `TsOrDsToDate` with a format, triggering a second `PARSE_TIMESTAMP`
- Fix: add an early return in the BigQuery branch so `TsOrDsToDate` is called without a format, producing the correct `CAST(PARSE_TIMESTAMP('%Y%m%d', col) AS DATE)`

## Test plan

- [ ] Unit tests pass: `uv run pytest tests/unit/standalone/test_functions.py::test_to_date -v`
- [ ] Added integration test with compact `"yyyyMMdd"` format that would fail with the double-parse bug
- [ ] BigQuery integration tests: `uv run pytest tests/integration/engines/test_int_functions.py::test_to_date -v -k bigquery`

Resolves #588

🤖 Generated with [Claude Code](https://claude.com/claude-code)