### PR TITLE
fix: skewness() fails with window functions in DuckDB

### DIFF
--- a/sqlframe/base/functions.py
+++ b/sqlframe/base/functions.py
@@ -544,12 +544,16 @@ def skewness(col: ColumnOrName) -> Column:
             * (count_col - lit_func(2))
             / (sqrt_func(count_col * (count_col - lit_func(1))))
         )
-        return (
+        result = (
             when_func(count_col == lit_func(0), lit_func(None))
             .when(count_col == lit_func(1), lit_func(None))
             .when(count_col == lit_func(2), lit_func(0.0))
             .otherwise(full_calc)
         )
+        window_func_expr = Column.invoke_anonymous_function(col, func_name).column_expression
+        result.column_expression._meta = result.column_expression._meta or {}
+        result.column_expression._meta["window_func"] = window_func_expr
+        return result
 
     return Column.invoke_anonymous_function(col, func_name)
 

--- a/tests/integration/engines/test_int_functions.py
+++ b/tests/integration/engines/test_int_functions.py
@@ -716,6 +716,17 @@ def test_skewness(get_session_and_func):
     assert df.agg(skewness(df.a)).collect() == [Row(value=0.0)]
 
 
+def test_skewness_over_window(get_session_and_func, get_window):
+    session, skewness = get_session_and_func("skewness")
+    Window = get_window(session)
+    df = session.createDataFrame(
+        [[1, "a"], [1, "a"], [2, "a"], [3, "b"], [3, "b"], [4, "b"]], ["c", "g"]
+    )
+    result = df.withColumn("skew", skewness("c").over(Window.partitionBy("g"))).collect()
+    assert result is not None
+    assert len(result) == 6
+
+
 def test_kurtosis(get_session_and_func):
     session, kurtosis = get_session_and_func("kurtosis")
     if isinstance(session, SnowflakeSession):

--- a/tests/unit/duck/test_functions.py
+++ b/tests/unit/duck/test_functions.py
@@ -1,0 +1,27 @@
+import pytest
+
+from sqlframe.duckdb import DuckDBSession, Window
+from sqlframe.duckdb import functions as F
+
+
+@pytest.fixture
+def session():
+    return DuckDBSession()
+
+
+def test_skewness_over_window(session):
+    """skewness().over() should produce valid SQL with OVER clause instead of wrapping the CASE expression."""
+    expr = F.skewness("cola").over(Window.partitionBy("colb"))
+    sql = expr.column_expression.sql(dialect="duckdb")
+    assert "OVER" in sql
+    assert "SKEWNESS" in sql
+    # Should NOT have CASE in the window version
+    assert "CASE" not in sql
+
+
+def test_skewness_aggregate(session):
+    """skewness() without .over() should still produce the CASE expression for aggregate use."""
+    expr = F.skewness("cola")
+    sql = expr.column_expression.sql(dialect="duckdb")
+    assert "CASE" in sql
+    assert "SKEWNESS" in sql


### PR DESCRIPTION
## Summary

Fixes `skewness()` failing when used with window functions in DuckDB. The issue was that `skewness()` returned a `CASE` expression for edge case handling, but `CASE` expressions are not valid as the base for window functions.

The fix stores a simple `SKEWNESS(col)` expression in the column metadata under `_meta["window_func"]`. When `.over()` is called, it uses this simple function call instead of the `CASE` expression as the window function base.

## Changes

- **sqlframe/base/functions.py**: Store simple function call in metadata for window function usage
- **tests/unit/duck/test_functions.py**: New DuckDB-specific unit tests verifying window and aggregate paths produce correct SQL
- **tests/integration/engines/test_int_functions.py**: Integration test exercising `skewness().over(Window.partitionBy())`

🤖 Generated with [Claude Code](https://claude.com/claude-code)