### PR TITLE
fix: preserve NULL in array_append for PySpark compatibility

### DIFF
--- a/sqlframe/base/functions.py
+++ b/sqlframe/base/functions.py
@@ -2139,8 +2139,12 @@ def array_append(col: ColumnOrName, value: ColumnOrLiteral) -> Column:
         return array_append_using_array_cat(col, value)
 
     value = value if isinstance(value, Column) else lit(value)
-    return Column.invoke_expression_over_column(
-        col, expression.ArrayAppend, expression=value.column_expression
+    return Column(
+        expression.ArrayAppend(
+            this=Column.ensure_col(col).column_expression,
+            expression=value.column_expression,
+            null_propagation=True,
+        )
     )
 
 

--- a/tests/integration/engines/test_int_functions.py
+++ b/tests/integration/engines/test_int_functions.py
@@ -2144,6 +2144,13 @@ def test_array_append(get_session_and_func, get_func):
     assert df.select(array_append(df.c1, "x")).collect() == [
         Row(value=["b", "a", "c", "x"]),
     ]
+    # NULL array should return NULL, not [value]
+    when = get_func("when", session)
+    col = get_func("col", session)
+    df_null = session.range(1).select(when(lit(False), lit(["a"])).alias("c1"))
+    assert df_null.select(array_append(col("c1"), "x")).collect() == [
+        Row(value=None),
+    ]
 
 
 def test_array_insert(get_session_and_func):

--- a/tests/unit/standalone/test_functions.py
+++ b/tests/unit/standalone/test_functions.py
@@ -2140,10 +2140,10 @@ def test_array_agg(expression, expected):
 @pytest.mark.parametrize(
     "expression, expected",
     [
-        (SF.array_append("cola", "val"), "ARRAY_APPEND(COALESCE(cola, ARRAY()), 'val')"),
+        (SF.array_append("cola", "val"), "ARRAY_APPEND(cola, 'val')"),
         (
             SF.array_append(SF.col("cola"), SF.col("colb")),
-            "ARRAY_APPEND(COALESCE(cola, ARRAY()), colb)",
+            "ARRAY_APPEND(cola, colb)",
         ),
     ],
 )


### PR DESCRIPTION
## Summary

Fixes array_append behavior where NULL arrays were incorrectly converted to empty arrays. When array_append is called on a NULL array with a value, it now returns NULL (matching PySpark semantics) instead of [value].

Sets null_propagation=True on ArrayAppend to tell sqlglot that PySpark propagates NULLs for this function. This generates dialect-specific SQL that preserves NULL semantics across DuckDB, Postgres, Spark, Snowflake, and other engines.

## Test Plan

- Unit test: Verified SQL output no longer includes unnecessary COALESCE wrapping
- Integration test: Added test case for NULL array input returning NULL
- All existing tests pass: 748 unit tests, 485 DuckDB integration tests

Resolves: https://github.com/eakmanrq/sqlframe/issues/460

🤖 Generated with [Claude Code](https://claude.com/claude-code)