### PR TITLE
fix: align dict row values to schema column order

### DIFF
--- a/sqlframe/base/session.py
+++ b/sqlframe/base/session.py
@@ -375,7 +375,7 @@ class _BaseSession(t.Generic[CATALOG, READER, WRITER, DF, TABLE, CONN, UDF_REGIS
                 if isinstance(row, Row):
                     row = row.asDict()
                 if isinstance(row, dict):
-                    row = row.values()
+                    row = [row.get(col_name) for col_name in column_mapping]
                 data_expressions.append(
                     exp.tuple_(*[F.lit(_maybe_convert(x)).column_expression for x in row])
                 )

--- a/tests/integration/engines/duck/test_duckdb_dataframe.py
+++ b/tests/integration/engines/duck/test_duckdb_dataframe.py
@@ -324,3 +324,17 @@ def test_special_characters_in_column_names(duckdb_session: DuckDBSession):
     assert result[0]["'ABC'"] == "a"
     assert result[0]["Map_CD1_%"] == "b"
     assert result[0]["\u2018ABC\u2019"] == "c"
+
+
+# https://github.com/eakmanrq/sqlframe/issues/557
+def test_dict_rows_missing_columns(duckdb_session: DuckDBSession):
+    df = duckdb_session.createDataFrame(
+        [{"name": "xxx"}, {"name": "yyy"}],
+        schema={"_id": "varchar", "name": "varchar"},
+    )
+    result = df.collect()
+    assert len(result) == 2
+    assert result[0]["_id"] is None
+    assert result[0]["name"] == "xxx"
+    assert result[1]["_id"] is None
+    assert result[1]["name"] == "yyy"

--- a/tests/unit/standalone/test_session.py
+++ b/tests/unit/standalone/test_session.py
@@ -42,6 +42,28 @@ def test_cdf_dict_rows(standalone_session: StandaloneSession, compare_sql: t.Cal
     compare_sql(df, expected)
 
 
+def test_cdf_dict_rows_missing_columns(
+    standalone_session: StandaloneSession, compare_sql: t.Callable
+):
+    df = standalone_session.createDataFrame(
+        [{"name": "xxx"}, {"name": "yyy"}],
+        schema={"_id": "string", "name": "string"},
+    )
+    expected = "SELECT CAST(`a1`.`_id` AS STRING) AS `_id`, CAST(`a1`.`name` AS STRING) AS `name` FROM VALUES (NULL, 'xxx'), (NULL, 'yyy') AS `a1`(`_id`, `name`)"
+    compare_sql(df, expected)
+
+
+def test_cdf_dict_rows_reordered_keys(
+    standalone_session: StandaloneSession, compare_sql: t.Callable
+):
+    df = standalone_session.createDataFrame(
+        [{"colb": "test", "cola": 1}],
+        schema={"cola": "bigint", "colb": "string"},
+    )
+    expected = "SELECT CAST(`a1`.`cola` AS BIGINT) AS `cola`, CAST(`a1`.`colb` AS STRING) AS `colb` FROM VALUES (1, 'test') AS `a1`(`cola`, `colb`)"
+    compare_sql(df, expected)
+
+
 def test_cdf_str_schema(standalone_session: StandaloneSession, compare_sql: t.Callable):
     df = standalone_session.createDataFrame([[1, "test"]], "cola INT, colb STRING")
     expected = "SELECT `a1`.`cola` AS `cola`, CAST(`a1`.`colb` AS STRING) AS `colb` FROM VALUES (1, 'test') AS `a1`(`cola`, `colb`)"


### PR DESCRIPTION
## Summary

Fixes issue #557: When `createDataFrame` is called with dict data rows and a schema, `row.values()` was extracting dict values in insertion order without aligning to the schema's column order. This caused:

1. **Missing columns** - Dicts missing keys from the schema produced fewer VALUES entries than column aliases, causing DuckDB BinderException
2. **Silent misalignment** - Different key ordering between data dicts and schema silently swapped column values

## Changes

- **sqlframe/base/session.py** - Changed `row.values()` to `[row.get(col_name) for col_name in column_mapping]` to properly align values to schema column order and fill `None` for missing keys
- **tests/unit/standalone/test_session.py** - Added unit tests for missing columns and reordered dict keys
- **tests/integration/engines/duck/test_duckdb_dataframe.py** - Added DuckDB integration test for the specific issue

All 1676 unit tests pass.

Resolves: https://github.com/eakmanrq/sqlframe/issues/557

🤖 Generated with [Claude Code](https://claude.com/claude-code)