### PR TITLE
fix(deps): update dependency sqlglot to support v30

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
     "prettytable<4",
-    "sqlglot>=28.0.0,<29.1",
+    "sqlglot>=28.0.0,<30.1",
     "typing_extensions",
     "more-itertools",
 ]

--- a/sqlframe/base/functions.py
+++ b/sqlframe/base/functions.py
@@ -2455,7 +2455,10 @@ def posexplode(col: ColumnOrName) -> Column:
 
 @meta(unsupported_engines=["duckdb", "postgres", "snowflake"])
 def explode_outer(col: ColumnOrName) -> Column:
-    return Column.invoke_expression_over_column(col, expression.ExplodeOuter)
+    # In sqlglot v30+, ExplodeOuter became a trait and can't be instantiated directly.
+    # Use _ExplodeOuter (Explode + ExplodeOuter combined class) when available.
+    expr_cls = getattr(expression, "_ExplodeOuter", expression.ExplodeOuter)
+    return Column.invoke_expression_over_column(col, expr_cls)
 
 
 @meta(unsupported_engines=["duckdb", "postgres", "snowflake"])

--- a/tests/unit/standalone/test_functions.py
+++ b/tests/unit/standalone/test_functions.py
@@ -33,6 +33,7 @@ def test_invoke_anonymous(name, func):
         "string_agg",  # alias for listagg
         "parse_json",  # ParseJSON in Spark dialect is a no-op; anonymous needed to emit PARSE_JSON(col)
         "time_diff",  # Anonymous needed: exp.TimeDiff generates TIMEDIFF not Spark's TIME_DIFF(unit, start, end)
+        "array_position",  # wrapped in coalesce to return 0 instead of NULL when not found
     }
     if "invoke_anonymous_function" in inspect.getsource(func) and name not in ignore_funcs:
         func = parse_one(f"{name}()", read="spark", error_level=ErrorLevel.IGNORE)

--- a/uv.lock
+++ b/uv.lock
@@ -2744,7 +2744,7 @@ requires-dist = [
     { name = "redshift-connector", marker = "extra == 'redshift'", specifier = ">=2.1.1,<2.2.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.4,<0.16" },
     { name = "snowflake-connector-python", extras = ["secure-local-storage"], marker = "extra == 'snowflake'", specifier = ">=3.10.0,<4.4" },
-    { name = "sqlglot", specifier = ">=28.0.0,<29.1" },
+    { name = "sqlglot", specifier = ">=28.0.0,<30.1" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.18" },
     { name = "types-psycopg2", marker = "extra == 'dev'", specifier = ">=2.9,<3" },
     { name = "typing-extensions" },


### PR DESCRIPTION
## Summary
- Bumps sqlglot dependency from `>=28.0.0,<29.1` to `>=28.0.0,<30.1` to support sqlglot v30
- Fixes `ExplodeOuter` breaking change: v30 restructured it into a trait (not directly instantiable), so we use `_ExplodeOuter` combined class when available with fallback for v29
- Adds `array_position` to `test_invoke_anonymous` ignore list since sqlglot v30 now recognizes it as `ArrayPosition` (function intentionally uses anonymous call for coalesce wrapping)

Closes #618

## Test plan
- [x] All 1820 unit tests pass with sqlglot v30
- [x] All 1820 unit tests pass with sqlglot v29 (backward compat)
- [x] All 344 DuckDB integration tests pass with sqlglot v30

🤖 Generated with [Claude Code](https://claude.com/claude-code)