### PR TITLE
Fix DuckDB percentile interpolation

### DIFF
--- a/sqlframe/base/functions.py
+++ b/sqlframe/base/functions.py
@@ -807,7 +807,7 @@ def percentile(
     if frequency:
         logger.warning("Frequency is not supported in all engines")
     return Column.invoke_expression_over_column(
-        col, expression.PercentileDisc, expression=lit(percentage)
+        col, expression.PercentileCont, expression=lit(percentage)
     )
 
 

--- a/tests/unit/duck/test_functions.py
+++ b/tests/unit/duck/test_functions.py
@@ -69,6 +69,9 @@ def test_percentile_matches_spark_continuous_interpolation(session):
         F.percentile("z", 0.3).alias("z"),
     ).collect()[0]
 
+    assert isinstance(result.a, float)
+    assert isinstance(result.b, float)
+    assert isinstance(result.z, float)
     assert math.isclose(result.a, 1.2000000000000002)
     assert math.isclose(result.b, 4.0)
     assert math.isclose(result.z, 7.6)

--- a/tests/unit/duck/test_functions.py
+++ b/tests/unit/duck/test_functions.py
@@ -53,3 +53,22 @@ def test_skewness_expression_generates_correct_dialect_names():
     assert "SKEWNESS" in skew.sql(dialect="duckdb")
     assert "SKEW" in skew.sql(dialect="snowflake")
     assert "SKEWNESS" in skew.sql(dialect="spark")
+
+
+def test_percentile_matches_spark_continuous_interpolation(session):
+    data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
+    rows = [
+        {key: value[index] for key, value in data.items()}
+        for index in range(len(data[next(iter(data.keys()))]))
+    ]
+    df = session.createDataFrame(rows)
+
+    result = df.select(
+        F.percentile("a", 0.1).alias("a"),
+        F.percentile("b", 0.5).alias("b"),
+        F.percentile("z", 0.3).alias("z"),
+    ).collect()[0]
+
+    assert math.isclose(result.a, 1.2000000000000002)
+    assert math.isclose(result.b, 4.0)
+    assert math.isclose(result.z, 7.6)


### PR DESCRIPTION
## Summary
- Use continuous percentile evaluation for non-Spark engines so DuckDB matches Spark interpolation semantics.
- Add a DuckDB regression test covering the reported integer and float percentile values.

## Tests
- uv run pytest tests/unit/duck/test_functions.py
- uv run pytest -m duckdb tests/integration/engines/test_int_functions.py::test_percentile

Resolves: https://github.com/eakmanrq/sqlframe/issues/625