### PR TITLE
Add Superset workspace configuration

### DIFF
--- a/.superset/config.json
+++ b/.superset/config.json
@@ -1,0 +1,5 @@
+{
+  "setup": ["make install-dev"],
+  "teardown": [],
+  "run": ["make docs-serve"]
+}


### PR DESCRIPTION
## Summary
- Add .superset/config.json for Superset workspace setup
- Use existing Makefile targets for dependency setup and docs server run command
- Leave teardown empty because setup does not start persistent services

## Verification
- python3 -m json.tool .superset/config.json