### PR TITLE
fix: support SQLGlot 30.0 minimum

### DIFF
--- a/.github/workflows/main.workflow.yaml
+++ b/.github/workflows/main.workflow.yaml
@@ -44,3 +44,52 @@ jobs:
         /usr/lib/postgresql/16/bin/postgres --version
     - name: Run tests
       run: uv run make local-test
+  minimum-sqlglot:
+    runs-on: ubuntu-latest
+    env:
+      PYTEST_XDIST_AUTO_NUM_WORKERS: 4
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        python-version: '3.12'
+        enable-cache: true
+    - name: Resolve SQLGlot minimum from project metadata
+      id: resolve_sqlglot
+      shell: bash
+      run: |
+        set -euo pipefail
+        requirements_file="$(mktemp)"
+        uv pip compile pyproject.toml --resolution lowest-direct --no-deps --quiet --output-file "$requirements_file"
+
+        sqlglot_pin_count=0
+        sqlglot_pin=""
+        while IFS= read -r pin; do
+          sqlglot_pin_count=$((sqlglot_pin_count + 1))
+          sqlglot_pin="$pin"
+        done < <(grep -iE '^sqlglot==[^[:space:]]+$' "$requirements_file" || true)
+        if [[ "$sqlglot_pin_count" -ne 1 ]]; then
+          echo "Expected exactly one SQLGlot pin, found $sqlglot_pin_count" >&2
+          cat "$requirements_file" >&2
+          exit 1
+        fi
+
+        echo "Resolved SQLGlot minimum from pyproject.toml: $sqlglot_pin"
+        echo "sqlglot_pin=$sqlglot_pin" >> "$GITHUB_OUTPUT"
+        {
+          echo "### SQLGlot minimum compatibility"
+          echo
+          echo "Resolved from pyproject.toml: $sqlglot_pin."
+        } >> "$GITHUB_STEP_SUMMARY"
+    - name: Install normal dependencies
+      run: uv sync --all-extras --locked
+    - name: Layer resolved SQLGlot minimum
+      env:
+        SQLGLOT_PIN: ${{ steps.resolve_sqlglot.outputs.sqlglot_pin }}
+      run: |
+        uv pip install --python .venv/bin/python "$SQLGLOT_PIN"
+        .venv/bin/python -c 'import sqlglot; print(f"Testing SQLGlot {sqlglot.__version__}")'
+    - name: Run unit tests at resolved SQLGlot minimum
+      run: uv run --no-sync pytest -n 0 tests/unit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
     "prettytable<4",
-    "sqlglot>=28.0.0,<30.13",
+    "sqlglot>=30.0.0,<30.13",
     "typing_extensions",
     "more-itertools",
 ]

--- a/sqlframe/base/functions.py
+++ b/sqlframe/base/functions.py
@@ -1731,7 +1731,7 @@ def concat_ws(sep: str, *cols: ColumnOrName) -> Column:
         expression.ConcatWs(
             expressions=[lit(sep).column_expression]
             + [Column.ensure_col(col).column_expression for col in cols],
-            coalesce=True,
+            coalesce=getattr(session.execution_dialect, "CONCAT_WS_COALESCE", False),
         )
     )
 
@@ -2937,6 +2937,13 @@ def try_avg(col: ColumnOrName) -> Column:
 
 @meta()
 def try_divide(left: ColumnOrName, right: ColumnOrName) -> Column:
+    generator = _get_session().execution_dialect.generator_class
+    if (
+        generator.__module__.rsplit(".", 1)[-1] in {"spark", "databricks"}
+        and expression.SafeDivide not in generator.TRANSFORMS
+    ):
+        return Column.invoke_anonymous_function(left, "TRY_DIVIDE", right)
+
     return Column.invoke_expression_over_column(
         left, expression.SafeDivide, expression=Column.ensure_col(right).column_expression
     )

--- a/sqlframe/base/functions.py
+++ b/sqlframe/base/functions.py
@@ -2937,9 +2937,10 @@ def try_avg(col: ColumnOrName) -> Column:
 
 @meta()
 def try_divide(left: ColumnOrName, right: ColumnOrName) -> Column:
-    generator = _get_session().execution_dialect.generator_class
+    session = _get_session()
+    generator = session.execution_dialect.generator_class
     if (
-        generator.__module__.rsplit(".", 1)[-1] in {"spark", "databricks"}
+        session.execution_dialect_name in {"spark", "databricks"}
         and expression.SafeDivide not in generator.TRANSFORMS
     ):
         return Column.invoke_anonymous_function(left, "TRY_DIVIDE", right)

--- a/tests/unit/standalone/test_functions.py
+++ b/tests/unit/standalone/test_functions.py
@@ -3082,14 +3082,19 @@ def test_try_divide(expression, expected):
 
 
 @pytest.mark.parametrize("dialect", ["spark", "databricks"])
-def test_try_divide_spark_family_without_native_safe_divide(dialect):
+def test_try_divide_spark_family_without_native_safe_divide(dialect, monkeypatch):
     from sqlframe.standalone.session import StandaloneSession
 
     session = StandaloneSession.builder.config("sqlframe.execution.dialect", dialect).getOrCreate()
+    generator = session.execution_dialect.generator_class
+    monkeypatch.setattr(generator, "__module__", "sqlglot.generators")
+    monkeypatch.delitem(generator.TRANSFORMS, exp.SafeDivide, raising=False)
 
+    result = SF.try_divide("cola", "colb")
+
+    assert isinstance(result.column_expression, exp.Anonymous)
     assert (
-        SF.try_divide("cola", "colb").column_expression.sql(dialect=session.execution_dialect)
-        == "TRY_DIVIDE(cola, colb)"
+        result.column_expression.sql(dialect=session.execution_dialect) == "TRY_DIVIDE(cola, colb)"
     )
 
 

--- a/tests/unit/standalone/test_functions.py
+++ b/tests/unit/standalone/test_functions.py
@@ -1,6 +1,7 @@
 import datetime
 import inspect
 import operator
+from importlib.metadata import requires
 
 import pytest
 from sqlglot import expressions as exp
@@ -35,6 +36,7 @@ def test_invoke_anonymous(name, func):
         "time_diff",  # Anonymous needed: exp.TimeDiff generates TIMEDIFF not Spark's TIME_DIFF(unit, start, end)
         "array_position",  # wrapped in coalesce to return 0 instead of NULL when not found
         "named_struct",  # SQLGlot parses named_struct as Struct, which emits STRUCT instead
+        "try_divide",  # Uses native SafeDivide when the active generator supports it
     }
     if "invoke_anonymous_function" in inspect.getsource(func) and name not in ignore_funcs:
         func = parse_one(f"{name}()", read="spark", error_level=ErrorLevel.IGNORE)
@@ -1802,6 +1804,19 @@ def test_concat_ws(expression, expected):
     assert expression.column_expression.sql(dialect="spark") == expected
 
 
+def test_concat_ws_preserves_redshift_translation():
+    from sqlframe.standalone.session import StandaloneSession
+
+    session = StandaloneSession.builder.config(
+        "sqlframe.execution.dialect", "redshift"
+    ).getOrCreate()
+
+    assert (
+        SF.concat_ws("-", "cola", "colb").column_expression.sql(dialect=session.execution_dialect)
+        == "cola || '-' || colb"
+    )
+
+
 @pytest.mark.parametrize(
     "expression, expected",
     [
@@ -3064,6 +3079,43 @@ def test_try_avg(expression, expected):
 )
 def test_try_divide(expression, expected):
     assert expression.column_expression.sql(dialect="spark") == expected
+
+
+@pytest.mark.parametrize("dialect", ["spark", "databricks"])
+def test_try_divide_spark_family_without_native_safe_divide(dialect):
+    from sqlframe.standalone.session import StandaloneSession
+
+    session = StandaloneSession.builder.config("sqlframe.execution.dialect", dialect).getOrCreate()
+
+    assert (
+        SF.try_divide("cola", "colb").column_expression.sql(dialect=session.execution_dialect)
+        == "TRY_DIVIDE(cola, colb)"
+    )
+
+
+def test_try_divide_non_spark_retains_safe_divide():
+    from sqlframe.standalone.session import StandaloneSession
+
+    session = StandaloneSession.builder.config(
+        "sqlframe.execution.dialect", "snowflake"
+    ).getOrCreate()
+
+    assert (
+        SF.try_divide("cola", "colb").column_expression.sql(dialect=session.execution_dialect)
+        == "IFF(colb <> 0, cola / colb, NULL)"
+    )
+
+
+def test_sqlglot_requirement_is_singular_in_distribution_metadata():
+    sqlglot_requirements = [
+        requirement.split(";", 1)[0].strip()
+        for requirement in requires("sqlframe") or []
+        if requirement.split(";", 1)[0].strip().lower().startswith("sqlglot")
+    ]
+
+    assert len(sqlglot_requirements) == 1
+    assert ">=30.0.0" in sqlglot_requirements[0]
+    assert "<30.13" in sqlglot_requirements[0]
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -2760,7 +2760,7 @@ requires-dist = [
     { name = "redshift-connector", marker = "extra == 'redshift'", specifier = ">=2.1.1,<2.2.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.4,<0.16" },
     { name = "snowflake-connector-python", extras = ["secure-local-storage"], marker = "extra == 'snowflake'", specifier = ">=3.10.0,<4.5" },
-    { name = "sqlglot", specifier = ">=28.0.0,<30.13" },
+    { name = "sqlglot", specifier = ">=30.0.0,<30.13" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.18" },
     { name = "types-psycopg2", marker = "extra == 'dev'", specifier = ">=2.9,<3" },
     { name = "typing-extensions" },


### PR DESCRIPTION
## Summary

- Raise SQLGlot's supported range to `>=30.0.0,<30.13`, matching SQLFrame's use of `exp.Expr` and closing #637.
- Keep `concat_ws` and `try_divide` compatible across SQLGlot capability sets using execution-dialect capability checks and the Spark-family `TRY_DIVIDE` fallback.
- Add a metadata-derived minimum-SQLGlot CI job that resolves the lowest direct pin from `pyproject.toml`, layers it over the normal locked environment, and runs the unit suite.

## Context

The reviewed branch and focused QA evidence confirm the dependency boundary, dialect routing, lockfile metadata, and minimum-version workflow guard. The change is limited to the five reviewed files and preserves the existing normal locked SQLGlot path.

## Verification

- `uv run --isolated --python 3.12 --all-extras --with 'sqlglot==30.0.0' pytest -n 0 tests/unit` — 1832 passed; one existing `pytest.mark.fast` warning.
- `uv run pytest -n auto tests/unit` — 1832 passed; ten existing `pytest.mark.fast` warnings.
- `uv run pre-commit run --all-files` — ruff, ruff-format, and ty passed.
- `uv run ty check` — passed.
- `uv lock --check` — passed.
- `uv pip compile pyproject.toml --resolution lowest-direct --no-deps --quiet | rg -i '^sqlglot=='` — exactly `sqlglot==30.0.0`.
- `git diff --check origin/main...HEAD` — passed.
- Focused QA/review evidence: 16 compatibility tests passed, SQLGlot 29.x resolution was rejected, and Spark/Databricks plus non-Spark division routing matched the intended behavior.

## Notes

- This pull request is intentionally draft and has not been merged.
- The existing unregistered `pytest.mark.fast` warning is test-harness hygiene only; no test failures remain.
- Residual risk is limited to GitHub-hosted workflow shell/runtime validation.

Closes #637
